### PR TITLE
Fix doc build with error-stack feature

### DIFF
--- a/src/compat/mod.rs
+++ b/src/compat/mod.rs
@@ -148,7 +148,7 @@ pub trait IntoRootcause {
 pub mod anyhow;
 
 #[cfg(feature = "error-stack")]
-#[cfg_attr(docsrs, oc(cfg(feature = "error-stack")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "error-stack")))]
 pub mod error_stack;
 
 #[cfg(feature = "eyre")]


### PR DESCRIPTION
This fixes the doc build on docs.rs by correcting the typo.

https://docs.rs/crate/rootcause/latest/builds/2681396