### PR TITLE
Fix ROOTCAUSE_MATCHER in Windows non-Cargo builds

### DIFF
--- a/rootcause-backtrace/src/lib.rs
+++ b/rootcause-backtrace/src/lib.rs
@@ -630,7 +630,10 @@ const fn get_rootcause_backtrace_matcher(
     if std::path::MAIN_SEPARATOR == '/' {
         assert!(suffix.eq_ignore_ascii_case("/src/lib.rs"));
     } else {
-        assert!(suffix.eq_ignore_ascii_case(r#"/src\lib.rs"#));
+        assert!(
+            suffix.eq_ignore_ascii_case(r#"\src\lib.rs"#)
+                || suffix.eq_ignore_ascii_case(r#"/src\lib.rs"#)
+        );
     }
 
     let (matcher_prefix, _) = file.split_at(prefix_len + 4);


### PR DESCRIPTION
The mixing of separators in `/src\lib.rs` is a quirk of how Cargo constructs the crate root path. It is not necessarily reproducible in other build systems. For example Buck consistently uses the platform's path separator: `…\src\lib.rs` on Windows, causing `rootcause-backtrace` to fail during const evaluation.

```console
error[E0080]: evaluation panicked: assertion failed: suffix.eq_ignore_ascii_case(r#"/src\lib.rs"#)
   --> third-party\rust\vendor\rootcause-backtrace-0.11.1\src\lib.rs:652:5
    |
652 |     get_rootcause_backtrace_matcher(rootcause::__private::ROOTCAUSE_LOCATION);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `ROOTCAUSE_MATCHER` failed inside this call
    |
note: inside `get_rootcause_backtrace_matcher`
   --> third-party\rust\vendor\rootcause-backtrace-0.11.1\src\lib.rs:632:9
    |
632 |         assert!(suffix.eq_ignore_ascii_case(r#"/src\lib.rs"#));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
    |         the failure occurred here
    |         in this macro invocation
    |
   --> third-party\rust\toolchain\sysroot\1.93.0\library\core\src\macros\mod.rs:1689:5
    |
    = note: in this expansion of `assert!`

error[E0080]: evaluation panicked: assertion failed: suffix.eq_ignore_ascii_case(r#"/src\lib.rs"#)
   --> third-party\rust\vendor\rootcause-backtrace-0.11.1\src\lib.rs:650:5
    |
650 |     get_rootcause_backtrace_matcher(Location::caller());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `ROOTCAUSE_BACKTRACE_MATCHER` failed inside this call
    |
note: inside `get_rootcause_backtrace_matcher`
   --> third-party\rust\vendor\rootcause-backtrace-0.11.1\src\lib.rs:632:9
    |
632 |         assert!(suffix.eq_ignore_ascii_case(r#"/src\lib.rs"#));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
    |         the failure occurred here
    |         in this macro invocation
    |
   --> third-party\rust\toolchain\sysroot\1.93.0\library\core\src\macros\mod.rs:1689:5
    |
    = note: in this expansion of `assert!`
```