### PR TITLE
Try simplifying the separator check on windows

### DIFF
--- a/rootcause-backtrace/src/lib.rs
+++ b/rootcause-backtrace/src/lib.rs
@@ -630,10 +630,7 @@ const fn get_rootcause_backtrace_matcher(
     if std::path::MAIN_SEPARATOR == '/' {
         assert!(suffix.eq_ignore_ascii_case("/src/lib.rs"));
     } else {
-        assert!(
-            suffix.eq_ignore_ascii_case(r#"\src\lib.rs"#)
-                || suffix.eq_ignore_ascii_case(r#"/src\lib.rs"#)
-        );
+        assert!(suffix.eq_ignore_ascii_case(r#"\src\lib.rs"#));
     }
 
     let (matcher_prefix, _) = file.split_at(prefix_len + 4);


### PR DESCRIPTION
I was curious if the extra check in #118 was actually necessary, so let's check