### PR TITLE
Support cross-compiling between Windows and non-Windows

### DIFF
--- a/rootcause-backtrace/build.rs
+++ b/rootcause-backtrace/build.rs
@@ -1,0 +1,10 @@
+use std::env;
+use std::fs;
+use std::path::{self, PathBuf};
+
+fn main() {
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let host_path_separator_file = out_dir.join("host_path_separator");
+    let literal = format!("'{}'", path::MAIN_SEPARATOR.escape_default());
+    fs::write(host_path_separator_file, literal).unwrap();
+}

--- a/rootcause-backtrace/src/lib.rs
+++ b/rootcause-backtrace/src/lib.rs
@@ -629,7 +629,7 @@ const fn get_rootcause_backtrace_matcher(
     let (prefix, suffix) = file.split_at(prefix_len);
     // Assert the suffix is /src/lib.rs (or \src\lib.rs on Windows)
     // This is a compile-time check that the caller location is valid
-    if std::path::MAIN_SEPARATOR == '/' {
+    if HOST_PATH_SEPARATOR == '/' {
         assert!(suffix.eq_ignore_ascii_case("/src/lib.rs"));
     } else {
         assert!(suffix.eq_ignore_ascii_case(r#"\src\lib.rs"#));
@@ -641,7 +641,7 @@ const fn get_rootcause_backtrace_matcher(
     while !splitter_prefix.is_empty() {
         let (new_prefix, last_char) = splitter_prefix.split_at(splitter_prefix.len() - 1);
         splitter_prefix = new_prefix;
-        if last_char.eq_ignore_ascii_case(std::path::MAIN_SEPARATOR_STR) {
+        if last_char.eq_ignore_ascii_case(HOST_PATH_SEPARATOR.encode_utf8(&mut [0])) {
             break;
         }
     }
@@ -649,6 +649,7 @@ const fn get_rootcause_backtrace_matcher(
     Some((matcher_prefix, splitter_prefix.len()))
 }
 
+const HOST_PATH_SEPARATOR: char = include!(concat!(env!("OUT_DIR"), "/host_path_separator"));
 const ROOTCAUSE_BACKTRACE_MATCHER: Option<(&str, usize)> =
     get_rootcause_backtrace_matcher(Location::caller());
 const ROOTCAUSE_MATCHER: Option<(&str, usize)> =


### PR DESCRIPTION
The evaluation of ROOTCAUSE_BACKTRACE_MATCHER is comparing the **target platform's** `MAIN_SEPARATOR` against the **host platform's** filepaths. In general those are going to use different path separators.

For example running `cargo check --manifest-path=rootcause-backtrace/Cargo.toml --target=x86_64-pc-windows-msvc` on non-Windows:

```console
error[E0080]: evaluation panicked: assertion failed: suffix.eq_ignore_ascii_case(r#"\src\lib.rs"#)
   --> rootcause-backtrace/src/lib.rs:653:5
    |
653 |     get_rootcause_backtrace_matcher(Location::caller());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `ROOTCAUSE_BACKTRACE_MATCHER` failed inside this call
    |
note: inside `get_rootcause_backtrace_matcher`
   --> rootcause-backtrace/src/lib.rs:635:9
    |
635 |         assert!(suffix.eq_ignore_ascii_case(r#"\src\lib.rs"#));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
```