### PR TITLE
Further enhancements to `Deref` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added a compatibility module for error-stack v0.7.
+- Implement `Deref<Target = dyn Error>` and `AsRef<dyn Error>` for `Report`, `ReportRef` and `ReportMut`. `Report<_, _, SendSync>` targets `dyn Error + Send + Sync`. Splitting `Deref` by thread-safety marker may break type inference at call sites of `Report::new_custom` / `Report::new`; use `new_sendsync_custom` / `new_local_custom` or explicit annotations to fix. [#147](https://github.com/rootcause-rs/rootcause/pull/147), [#149](https://github.com/rootcause-rs/rootcause/pull/149)
 
 ## [0.12.1] - 2026-02-19
 

--- a/src/compat/anyhow1.rs
+++ b/src/compat/anyhow1.rs
@@ -199,7 +199,7 @@ impl IntoRootcause for anyhow::Error {
 
     #[inline(always)]
     fn into_rootcause(self) -> Self::Output {
-        Report::new_custom::<AnyhowHandler>(self).into_dynamic()
+        Report::new_sendsync_custom::<AnyhowHandler>(self).into_dynamic()
     }
 }
 

--- a/src/compat/boxed_error.rs
+++ b/src/compat/boxed_error.rs
@@ -360,7 +360,7 @@ impl IntoRootcause for Box<dyn Error + Send + Sync> {
 
     #[inline(always)]
     fn into_rootcause(self) -> Self::Output {
-        Report::new_custom::<BoxedErrorHandler>(self).into_dynamic()
+        Report::new_sendsync_custom::<BoxedErrorHandler>(self).into_dynamic()
     }
 }
 
@@ -369,7 +369,7 @@ impl IntoRootcause for Box<dyn Error> {
 
     #[inline(always)]
     fn into_rootcause(self) -> Self::Output {
-        Report::new_custom::<BoxedErrorHandler>(self).into_dynamic()
+        Report::new_local_custom::<BoxedErrorHandler>(self).into_dynamic()
     }
 }
 

--- a/src/compat/eyre06.rs
+++ b/src/compat/eyre06.rs
@@ -199,7 +199,7 @@ impl IntoRootcause for eyre::Report {
 
     #[inline(always)]
     fn into_rootcause(self) -> Self::Output {
-        Report::new_custom::<EyreHandler>(self).into_dynamic()
+        Report::new_sendsync_custom::<EyreHandler>(self).into_dynamic()
     }
 }
 

--- a/src/report/mut_.rs
+++ b/src/report/mut_.rs
@@ -1191,7 +1191,10 @@ impl<'a, C: Sized> From<ReportMut<'a, C, Local>> for ReportMut<'a, Dynamic, Loca
 
 #[cfg(test)]
 mod tests {
-    use alloc::string::String;
+    use alloc::string::{String, ToString};
+    use core::error::Error as StdError;
+    use core::ops::Deref;
+    use thiserror::Error;
 
     use super::*;
 
@@ -1235,5 +1238,24 @@ mod tests {
         static_assertions::assert_not_impl_any!(ReportMut<'static, NonSend, Local>: Copy, Clone);
         static_assertions::assert_not_impl_any!(ReportMut<'static, Dynamic, SendSync>: Copy, Clone);
         static_assertions::assert_not_impl_any!(ReportMut<'static, Dynamic, Local>: Copy, Clone);
+    }
+
+    #[derive(Debug, Error)]
+    #[error("boom")]
+    struct Boom;
+
+    fn make_report() -> Report<Boom> {
+        Report::new(Boom)
+    }
+
+    #[test]
+    fn report_mut_derefs_to_dyn_error() {
+        let mut report = make_report();
+        let report_mut = report.as_mut();
+
+        let err: &dyn StdError = report_mut.deref();
+
+        assert!(err.to_string().contains("boom"));
+        assert!(report.source().is_none());
     }
 }

--- a/src/report/mut_.rs
+++ b/src/report/mut_.rs
@@ -1175,6 +1175,13 @@ impl<'a, C: ?Sized, T> core::ops::Deref for ReportMut<'a, C, T> {
     }
 }
 
+impl<'a, C: ?Sized, T> AsRef<dyn core::error::Error + 'a> for ReportMut<'a, C, T> {
+    #[inline(always)]
+    fn as_ref(&self) -> &(dyn core::error::Error + 'a) {
+        ErrorNoSourceWrapper::new(self)
+    }
+}
+
 impl<'a, C: ?Sized, T> Unpin for ReportMut<'a, C, T> {}
 
 impl<'a, C: Sized> From<ReportMut<'a, C, SendSync>> for ReportMut<'a, Dynamic, SendSync> {
@@ -1257,5 +1264,17 @@ mod tests {
 
         assert!(err.to_string().contains("boom"));
         assert!(report.source().is_none());
+    }
+
+    #[test]
+    fn report_mut_asrefs_to_dyn_error() {
+        let mut report = make_report();
+        let report_mut = report.as_mut();
+
+        fn takes_asref<'a>(err: impl AsRef<dyn StdError + 'a>) {
+            assert!(err.as_ref().to_string().contains("boom"));
+        }
+
+        takes_asref(report_mut);
     }
 }

--- a/src/report/mut_.rs
+++ b/src/report/mut_.rs
@@ -1167,6 +1167,10 @@ impl<'a, C: ?Sized, T> core::fmt::Debug for ReportMut<'a, C, T> {
     }
 }
 
+// `Report<_, _, SendSync>` derefs to `dyn Error + Send + Sync`. This isn't
+// split the same way because `ReportRef` / `ReportMut` aren't `Send + Sync`
+// today. See https://github.com/rootcause-rs/rootcause/issues/173 for whether
+// that could change.
 impl<'a, C: ?Sized, T> core::ops::Deref for ReportMut<'a, C, T> {
     type Target = dyn core::error::Error + 'a;
 

--- a/src/report/owned.rs
+++ b/src/report/owned.rs
@@ -1819,6 +1819,20 @@ impl<C: ?Sized, O> core::ops::Deref for Report<C, O, Local> {
     }
 }
 
+impl<C: ?Sized, O> AsRef<dyn core::error::Error + Send + Sync> for Report<C, O, SendSync> {
+    #[inline(always)]
+    fn as_ref(&self) -> &(dyn core::error::Error + Send + Sync + 'static) {
+        ErrorNoSourceWrapper::new(self)
+    }
+}
+
+impl<C: ?Sized, O> AsRef<dyn core::error::Error> for Report<C, O, Local> {
+    #[inline(always)]
+    fn as_ref(&self) -> &(dyn core::error::Error + 'static) {
+        ErrorNoSourceWrapper::new(self)
+    }
+}
+
 impl<C: ?Sized, O, T> Unpin for Report<C, O, T> {}
 
 macro_rules! from_impls {
@@ -1987,12 +2001,34 @@ mod tests {
     }
 
     #[test]
+    fn report_asrefs_to_dyn_error() {
+        let report = make_report();
+
+        fn takes_asref<'a>(err: impl AsRef<dyn StdError + Send + Sync + 'a>) {
+            assert!(err.as_ref().to_string().contains("boom"));
+        }
+
+        takes_asref(&report);
+    }
+
+    #[test]
     fn dynamic_report_derefs_to_dyn_error() {
         let report = make_dynamic_report();
 
         let err: &dyn StdError = report.deref();
 
         assert!(err.to_string().contains("boom"));
+    }
+
+    #[test]
+    fn dynamic_report_asrefs_to_dyn_error() {
+        let report = make_dynamic_report();
+
+        fn takes_asref<'a>(err: impl AsRef<dyn StdError + Send + Sync + 'a>) {
+            assert!(err.as_ref().to_string().contains("boom"));
+        }
+
+        takes_asref(&report);
     }
 
     #[test]
@@ -2005,12 +2041,34 @@ mod tests {
     }
 
     #[test]
+    fn cloneable_report_asrefs_to_dyn_error() {
+        let report = make_cloneable_report();
+
+        fn takes_asref<'a>(err: impl AsRef<dyn StdError + Send + Sync + 'a>) {
+            assert!(err.as_ref().to_string().contains("boom"));
+        }
+
+        takes_asref(&report);
+    }
+
+    #[test]
     fn local_report_derefs_to_dyn_error() {
         let report = make_local_report();
 
         let err: &dyn StdError = report.deref();
 
         assert!(err.to_string().contains("boom"));
+    }
+
+    #[test]
+    fn local_report_asrefs_to_dyn_error() {
+        let report = make_local_report();
+
+        fn takes_asref<'a>(err: impl AsRef<dyn StdError + 'a>) {
+            assert!(err.as_ref().to_string().contains("boom"));
+        }
+
+        takes_asref(&report);
     }
 
     #[test]

--- a/src/report/owned.rs
+++ b/src/report/owned.rs
@@ -1868,7 +1868,10 @@ from_impls!(
 
 #[cfg(test)]
 mod tests {
-    use alloc::string::String;
+    use alloc::string::{String, ToString};
+    use core::error::Error as StdError;
+    use core::ops::Deref;
+    use thiserror::Error;
 
     use super::*;
 
@@ -1946,5 +1949,120 @@ mod tests {
         static_assertions::assert_not_impl_any!(Report<NonSend, Cloneable, Local>: Copy);
         static_assertions::assert_not_impl_any!(Report<Dynamic, Cloneable, SendSync>: Copy);
         static_assertions::assert_not_impl_any!(Report<Dynamic, Cloneable, Local>: Copy);
+    }
+
+    #[derive(Debug, Error)]
+    #[error("boom")]
+    struct Boom;
+
+    #[derive(Debug, Error)]
+    enum Outer {
+        #[error(transparent)]
+        Inner(#[from] Report<Boom>),
+    }
+
+    fn make_report() -> Report<Boom> {
+        Report::new(Boom)
+    }
+
+    fn make_dynamic_report() -> Report<Dynamic> {
+        make_report().into_dynamic()
+    }
+
+    fn make_cloneable_report() -> Report<Boom, Cloneable> {
+        make_report().into_cloneable()
+    }
+
+    fn make_local_report() -> Report<Boom, Mutable, Local> {
+        make_report().into_local()
+    }
+
+    #[test]
+    fn report_derefs_to_dyn_error() {
+        let report = make_report();
+
+        let err: &(dyn StdError + Send + Sync) = report.deref();
+
+        assert!(err.to_string().contains("boom"));
+    }
+
+    #[test]
+    fn dynamic_report_derefs_to_dyn_error() {
+        let report = make_dynamic_report();
+
+        let err: &dyn StdError = report.deref();
+
+        assert!(err.to_string().contains("boom"));
+    }
+
+    #[test]
+    fn cloneable_report_derefs_to_dyn_error() {
+        let report = make_cloneable_report();
+
+        let err: &dyn StdError = report.deref();
+
+        assert!(err.to_string().contains("boom"));
+    }
+
+    #[test]
+    fn local_report_derefs_to_dyn_error() {
+        let report = make_local_report();
+
+        let err: &dyn StdError = report.deref();
+
+        assert!(err.to_string().contains("boom"));
+    }
+
+    #[test]
+    fn report_deref_supports_error_methods() {
+        let report = make_report();
+
+        assert!(report.source().is_none());
+
+        #[expect(deprecated)]
+        {
+            assert_eq!(
+                report.description(),
+                "description() is deprecated; use Display"
+            );
+        }
+    }
+
+    #[test]
+    fn thiserror_from_works_for_report() {
+        let report = make_report();
+
+        let outer: Outer = report.into();
+
+        match outer {
+            Outer::Inner(inner) => {
+                assert!(inner.to_string().contains("boom"));
+            }
+        }
+    }
+
+    #[test]
+    fn thiserror_question_mark_works_for_report() {
+        fn inner() -> Result<(), Report<Boom>> {
+            Err(make_report())
+        }
+
+        fn outer() -> Result<(), Outer> {
+            inner()?;
+            Ok(())
+        }
+
+        let err = outer().unwrap_err();
+        assert!(err.to_string().contains("boom"));
+    }
+
+    #[test]
+    fn report_is_usable_where_dyn_error_is_expected() {
+        fn takes_error(err: &dyn StdError) -> String {
+            err.to_string()
+        }
+
+        let report = make_report();
+        assert!(takes_error(report.deref()).contains("boom"));
     }
 }

--- a/src/report/owned.rs
+++ b/src/report/owned.rs
@@ -1803,8 +1803,16 @@ impl<C: ?Sized, O, T> core::fmt::Debug for Report<C, O, T> {
     }
 }
 
-impl<C: ?Sized, O, T> core::ops::Deref for Report<C, O, T> {
-    type Target = dyn core::error::Error;
+impl<C: ?Sized, O> core::ops::Deref for Report<C, O, SendSync> {
+    type Target = dyn core::error::Error + Send + Sync + 'static;
+
+    fn deref(&self) -> &Self::Target {
+        ErrorNoSourceWrapper::new(self)
+    }
+}
+
+impl<C: ?Sized, O> core::ops::Deref for Report<C, O, Local> {
+    type Target = dyn core::error::Error + 'static;
 
     fn deref(&self) -> &Self::Target {
         ErrorNoSourceWrapper::new(self)

--- a/src/report/owned.rs
+++ b/src/report/owned.rs
@@ -2004,7 +2004,7 @@ mod tests {
     fn report_asrefs_to_dyn_error() {
         let report = make_report();
 
-        fn takes_asref<'a>(err: impl AsRef<dyn StdError + Send + Sync + 'a>) {
+        fn takes_asref(err: impl AsRef<dyn StdError + Send + Sync>) {
             assert!(err.as_ref().to_string().contains("boom"));
         }
 
@@ -2024,7 +2024,7 @@ mod tests {
     fn dynamic_report_asrefs_to_dyn_error() {
         let report = make_dynamic_report();
 
-        fn takes_asref<'a>(err: impl AsRef<dyn StdError + Send + Sync + 'a>) {
+        fn takes_asref(err: impl AsRef<dyn StdError + Send + Sync>) {
             assert!(err.as_ref().to_string().contains("boom"));
         }
 
@@ -2044,7 +2044,7 @@ mod tests {
     fn cloneable_report_asrefs_to_dyn_error() {
         let report = make_cloneable_report();
 
-        fn takes_asref<'a>(err: impl AsRef<dyn StdError + Send + Sync + 'a>) {
+        fn takes_asref(err: impl AsRef<dyn StdError + Send + Sync>) {
             assert!(err.as_ref().to_string().contains("boom"));
         }
 
@@ -2064,7 +2064,7 @@ mod tests {
     fn local_report_asrefs_to_dyn_error() {
         let report = make_local_report();
 
-        fn takes_asref<'a>(err: impl AsRef<dyn StdError + 'a>) {
+        fn takes_asref(err: impl AsRef<dyn StdError>) {
             assert!(err.as_ref().to_string().contains("boom"));
         }
 
@@ -2076,14 +2076,6 @@ mod tests {
         let report = make_report();
 
         assert!(report.source().is_none());
-
-        #[expect(deprecated)]
-        {
-            assert_eq!(
-                report.description(),
-                "description() is deprecated; use Display"
-            );
-        }
     }
 
     #[test]

--- a/src/report/ref_.rs
+++ b/src/report/ref_.rs
@@ -1086,7 +1086,10 @@ from_impls!(
 
 #[cfg(test)]
 mod tests {
-    use alloc::string::String;
+    use alloc::string::{String, ToString};
+    use core::error::Error as StdError;
+    use core::ops::Deref;
+    use thiserror::Error;
 
     use super::*;
     use crate::markers::{Mutable, Uncloneable};
@@ -1193,5 +1196,24 @@ mod tests {
         let report_ref: ReportRef<'_, NonSendSyncError, Uncloneable, Local> = report.as_ref();
         let preformatted: Report<PreformattedContext, Mutable, SendSync> = report_ref.preformat();
         assert_eq!(alloc::format!("{report}"), alloc::format!("{preformatted}"));
+    }
+
+    #[derive(Debug, Error)]
+    #[error("boom")]
+    struct Boom;
+
+    fn make_report() -> Report<Boom> {
+        Report::new(Boom)
+    }
+
+    #[test]
+    fn report_ref_derefs_to_dyn_error() {
+        let report = make_report();
+        let report_ref = report.as_ref();
+
+        let err: &dyn StdError = report_ref.deref();
+
+        assert!(err.to_string().contains("boom"));
+        assert!(report.source().is_none());
     }
 }

--- a/src/report/ref_.rs
+++ b/src/report/ref_.rs
@@ -1036,6 +1036,13 @@ impl<'a, C: ?Sized, O, T> core::ops::Deref for ReportRef<'a, C, O, T> {
     }
 }
 
+impl<'a, C: ?Sized, O, T> AsRef<dyn core::error::Error + 'a> for ReportRef<'a, C, O, T> {
+    #[inline(always)]
+    fn as_ref(&self) -> &(dyn core::error::Error + 'a) {
+        ErrorNoSourceWrapper::new(self)
+    }
+}
+
 impl<'a, C: ?Sized, O, T> Unpin for ReportRef<'a, C, O, T> {}
 
 macro_rules! from_impls {
@@ -1215,5 +1222,17 @@ mod tests {
 
         assert!(err.to_string().contains("boom"));
         assert!(report.source().is_none());
+    }
+
+    #[test]
+    fn report_ref_asrefs_to_dyn_error() {
+        let report = make_report();
+        let report_ref = report.as_ref();
+
+        fn takes_asref<'a>(err: impl AsRef<dyn StdError + 'a>) {
+            assert!(err.as_ref().to_string().contains("boom"));
+        }
+
+        takes_asref(report_ref);
     }
 }

--- a/src/report/ref_.rs
+++ b/src/report/ref_.rs
@@ -1028,6 +1028,10 @@ impl<'a, C: ?Sized, O, T> core::fmt::Debug for ReportRef<'a, C, O, T> {
     }
 }
 
+// `Report<_, _, SendSync>` derefs to `dyn Error + Send + Sync`. This isn't
+// split the same way because `ReportRef` / `ReportMut` aren't `Send + Sync`
+// today. See https://github.com/rootcause-rs/rootcause/issues/173 for whether
+// that could change.
 impl<'a, C: ?Sized, O, T> core::ops::Deref for ReportRef<'a, C, O, T> {
     type Target = dyn core::error::Error + 'a;
 

--- a/src/report_collection/owned.rs
+++ b/src/report_collection/owned.rs
@@ -642,7 +642,7 @@ impl<C: ?Sized, T> ReportCollection<C, T> {
     /// # };
     /// #
     /// let mut collection = ReportCollection::<i32, SendSync>::new();
-    /// let report = Report::new_custom::<Display>(42i32).into_cloneable();
+    /// let report = Report::new_sendsync_custom::<Display>(42i32).into_cloneable();
     /// collection.push(report);
     /// let dynamic = collection.as_dynamic();
     /// let first = dynamic.iter().next().unwrap();
@@ -719,7 +719,7 @@ impl<C: ?Sized, T> ReportCollection<C, T> {
     /// # };
     /// #
     /// let mut collection = ReportCollection::<i32, SendSync>::new();
-    /// let report = Report::new_custom::<Display>(42i32).into_cloneable();
+    /// let report = Report::new_sendsync_custom::<Display>(42i32).into_cloneable();
     /// collection.push(report);
     /// let local = collection.as_local();
     /// let first = local.iter().next().unwrap();


### PR DESCRIPTION
The first commit is likely to the the most controversial as it uncovers some latent type inference ambiguities, which might impact downstream crates.

The second commit adds unit tests.

The third commit, following `anyhow`'s lead, adds `AsRef` impls in addition to the `Deref`s.