### PR TITLE
Add compat-error-stack07 feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a compatibility module for error-stack v0.7.
+
 ## [0.12.1] - 2026-02-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-stack"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99a1a66f27cc1b82d6b8c2d24b3b1e90e6e67004a448081bbe58bd537f72a7c8"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,6 +1012,7 @@ dependencies = [
  "derive_more",
  "error-stack 0.5.0",
  "error-stack 0.6.0",
+ "error-stack 0.7.0",
  "eyre",
  "hashbrown",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ default = []
 # Compatibility traits
 compat-anyhow1 = ["dep:anyhow"]
 compat-error-stack05 = ["dep:error-stack05"]
-compat-error-stack06 = ["dep:error-stack"]
+compat-error-stack06 = ["dep:error-stack06"]
+compat-error-stack07 = ["dep:error-stack07"]
 compat-eyre06 = ["dep:eyre"]
 
 [dependencies]
@@ -30,8 +31,9 @@ triomphe = { version = "0.1.15", default-features = false }
 
 # Optional dependencies
 anyhow = { version = "1.0.102", default-features = false, optional = true }
-error-stack = { version = "0.6.0", default-features = false, optional = true }
 error-stack05 = { package = "error-stack", version = "0.5.0", default-features = false, optional = true }
+error-stack06 = { package = "error-stack", version = "0.6.0", default-features = false, optional = true }
+error-stack07 = { package = "error-stack", version = "0.7.0", default-features = false, optional = true }
 eyre = { version = "0.6.12", default-features = false, optional = true }
 
 # Internal dependencies
@@ -63,7 +65,7 @@ required-features = ["compat-anyhow1"]
 
 [[example]]
 name = "error_stack_interop"
-required-features = ["compat-error-stack06"]
+required-features = ["compat-error-stack07"]
 
 [[example]]
 name = "eyre_interop"

--- a/examples/error_stack_interop.rs
+++ b/examples/error_stack_interop.rs
@@ -6,7 +6,7 @@
 //! # Running this Example
 //!
 //! ```bash
-//! cargo run --example error_stack_interop --features compat-error-stack06
+//! cargo run --example error_stack_interop --features compat-error-stack07
 //! ```
 //!
 //! # Conversion Overview
@@ -21,10 +21,11 @@
 //! - `?` operator - Automatically converts `Report` to `error_stack::Report` in
 //!   error-stack functions
 
+use error_stack07 as error_stack;
 // Import only what we need to avoid conflicting with error-stack's attach trait
 use rootcause::{
     Report, bail,
-    compat::{IntoRootcause, error_stack06::IntoErrorStack},
+    compat::{IntoRootcause, error_stack07::IntoErrorStack},
 };
 
 // ============================================================================

--- a/src/compat/error_stack07.rs
+++ b/src/compat/error_stack07.rs
@@ -1,8 +1,8 @@
-//! Bidirectional integration with the [`error-stack`] 0.6.x error handling
+//! Bidirectional integration with the [`error-stack`] 0.7.x error handling
 //! library.
 //!
-//! This module specifically supports `error-stack` version 0.6.x. To enable
-//! this integration, add the `compat-error-stack06` feature flag to your
+//! This module specifically supports `error-stack` version 0.7.x. To enable
+//! this integration, add the `compat-error-stack07` feature flag to your
 //! `Cargo.toml`.
 //!
 //! # Overview
@@ -24,14 +24,14 @@
 //! reports into rootcause reports:
 //!
 //! ```
-//! # use error_stack06 as error_stack;
+//! # use error_stack07 as error_stack;
 //! use std::io;
 //!
 //! use rootcause::prelude::*;
 //!
 //! fn error_stack_function() -> Result<String, error_stack::Report<io::Error>> {
-//!     Err(error_stack::report!(io::Error::from(
-//!         io::ErrorKind::NotFound
+//!     Err(error_stack::Report::new(io::Error::from(
+//!         io::ErrorKind::NotFound,
 //!     )))
 //! }
 //!
@@ -45,10 +45,10 @@
 //! You can also convert individual [`error_stack::Report`] values:
 //!
 //! ```
-//! # use error_stack06 as error_stack;
+//! # use error_stack07 as error_stack;
 //! use rootcause::prelude::*;
 //!
-//! let es_report = error_stack::report!(std::io::Error::from(std::io::ErrorKind::NotFound));
+//! let es_report = error_stack::Report::new(std::io::Error::from(std::io::ErrorKind::NotFound));
 //! let report: Report<_> = es_report.into_rootcause();
 //!
 //! // The report preserves error-stack's formatting
@@ -61,8 +61,8 @@
 //! error-stack reports:
 //!
 //! ```
-//! # use error_stack06 as error_stack;
-//! use rootcause::{compat::error_stack06::IntoErrorStack, prelude::*};
+//! # use error_stack07 as error_stack;
+//! use rootcause::{compat::error_stack07::IntoErrorStack, prelude::*};
 //!
 //! fn rootcause_function() -> Result<String, Report> {
 //!     Err(report!("database connection failed"))
@@ -79,8 +79,8 @@
 //! You can also convert individual [`Report`] values:
 //!
 //! ```
-//! # use error_stack06 as error_stack;
-//! use rootcause::{compat::error_stack06::IntoErrorStack, prelude::*};
+//! # use error_stack07 as error_stack;
+//! use rootcause::{compat::error_stack07::IntoErrorStack, prelude::*};
 //!
 //! let report = report!("operation failed").attach("debug info");
 //! let es_report: error_stack::Report<_> = report.into_error_stack();
@@ -92,7 +92,7 @@
 //! Or using the `From` trait directly:
 //!
 //! ```
-//! # use error_stack06 as error_stack;
+//! # use error_stack07 as error_stack;
 //! use rootcause::prelude::*;
 //!
 //! let report: Report = report!("operation failed");
@@ -105,7 +105,7 @@
 //! The `From` trait also works with the `?` operator for automatic conversion:
 //!
 //! ```
-//! # use error_stack06 as error_stack;
+//! # use error_stack07 as error_stack;
 //! use rootcause::prelude::*;
 //!
 //! fn rootcause_function() -> Result<String, Report> {
@@ -137,7 +137,7 @@
 
 use core::marker::PhantomData;
 
-use error_stack06 as error_stack;
+use error_stack07 as error_stack;
 use rootcause_internals::handlers::ContextHandler;
 
 use crate::{
@@ -166,8 +166,8 @@ use crate::{
 /// # Examples
 ///
 /// ```
-/// # use error_stack06 as error_stack;
-/// use rootcause::{Report, compat::error_stack06::ErrorStackHandler};
+/// # use error_stack07 as error_stack;
+/// use rootcause::{Report, compat::error_stack07::ErrorStackHandler};
 ///
 /// let es_report = error_stack::Report::new(std::io::Error::from(std::io::ErrorKind::NotFound));
 /// let report: Report<_> = Report::new_custom::<ErrorStackHandler<_>>(es_report);
@@ -241,8 +241,8 @@ where
 /// ## Converting a Result
 ///
 /// ```
-/// # use error_stack06 as error_stack;
-/// use rootcause::{compat::error_stack06::IntoErrorStack, prelude::*};
+/// # use error_stack07 as error_stack;
+/// use rootcause::{compat::error_stack07::IntoErrorStack, prelude::*};
 ///
 /// fn uses_rootcause() -> Result<i32, Report> {
 ///     Err(report!("failed"))
@@ -257,8 +257,8 @@ where
 /// ## Converting a Report
 ///
 /// ```
-/// # use error_stack06 as error_stack;
-/// use rootcause::{compat::error_stack06::IntoErrorStack, prelude::*};
+/// # use error_stack07 as error_stack;
+/// use rootcause::{compat::error_stack07::IntoErrorStack, prelude::*};
 ///
 /// let report = report!("operation failed").attach("debug info");
 /// let es_report: error_stack::Report<_> = report.into_error_stack();
@@ -272,7 +272,7 @@ where
 /// You can also use the `From` trait for explicit conversions:
 ///
 /// ```
-/// # use error_stack06 as error_stack;
+/// # use error_stack07 as error_stack;
 /// use rootcause::prelude::*;
 ///
 /// let report: Report = report!("error");
@@ -306,8 +306,8 @@ pub trait IntoErrorStack<C: ?Sized> {
     /// # Examples
     ///
     /// ```
-    /// # use error_stack06 as error_stack;
-    /// use rootcause::{compat::error_stack06::IntoErrorStack, prelude::*};
+    /// # use error_stack07 as error_stack;
+    /// use rootcause::{compat::error_stack07::IntoErrorStack, prelude::*};
     ///
     /// // Convert a result
     /// let result: Result<i32, Report> = Ok(42);

--- a/src/compat/mod.rs
+++ b/src/compat/mod.rs
@@ -17,6 +17,8 @@
 //!   handling library (requires the `compat-error-stack05` feature flag)
 //! - [`error_stack06`] - Integration with the `error-stack` 0.6.x error
 //!   handling library (requires the `compat-error-stack06` feature flag)
+//! - [`error_stack07`] - Integration with the `error-stack` 0.7.x error
+//!   handling library (requires the `compat-error-stack07` feature flag)
 //! - [`eyre06`] - Integration with the `eyre` 0.6.x error handling library
 //!   (requires the `compat-eyre06` feature flag)
 //!
@@ -98,14 +100,15 @@ use crate::{
 /// handling libraries:
 /// - [`anyhow1`] module provides implementations for [`anyhow::Error`] and
 ///   [`anyhow::Result<T>`]
-/// - [`error_stack05`] and [`error_stack06`] modules provide implementations
-///   for [`error_stack::Report<C>`] and `Result<T, error_stack::Report<C>>`
+/// - [`error_stack05`], [`error_stack06`], and [`error_stack07`] modules
+///   provide implementations for [`error_stack::Report<C>`] and `Result<T,
+///   error_stack::Report<C>>`
 /// - [`eyre06`] module provides implementations for [`eyre::Report`] and
 ///   [`eyre::Result<T>`]
 ///
 /// [`anyhow::Error`]: ::anyhow::Error
 /// [`anyhow::Result<T>`]: ::anyhow::Result
-/// [`error_stack::Report<C>`]: ::error_stack::Report
+/// [`error_stack::Report<C>`]: ::error_stack07::Report
 ///
 /// # Examples
 ///
@@ -173,6 +176,10 @@ pub mod error_stack05;
 #[cfg(feature = "compat-error-stack06")]
 #[cfg_attr(docsrs, doc(cfg(feature = "compat-error-stack06")))]
 pub mod error_stack06;
+
+#[cfg(feature = "compat-error-stack07")]
+#[cfg_attr(docsrs, doc(cfg(feature = "compat-error-stack07")))]
+pub mod error_stack07;
 
 #[cfg(feature = "compat-eyre06")]
 #[cfg_attr(docsrs, doc(cfg(feature = "compat-eyre06")))]


### PR DESCRIPTION
Adds a compat module for error-stack 0.7 alongside the existing 0.5 and 0.6 ones.

The 0.7 module mirrors 0.6, but `error_stack::Context` was removed in 0.7, so the trait bounds are spelled directly with `core::error::Error` (`source()` instead of `__source()`, as in 0.6). The example is migrated to 0.7.