### PR TITLE
ci: only save rust-cache on main

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run fmt
         run: cargo fmt --check
@@ -59,6 +61,8 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run cargo-deny
         uses: EmbarkStudios/cargo-deny-action@v2
@@ -80,6 +84,8 @@ jobs:
           toolchain: nightly
           components: miri rust-src
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run tests with miri
         run: |


### PR DESCRIPTION
Gate the rust-cache post-job save on `main`, matching the documented `save-if` pattern from the rust-cache README. Restore still happens on every run; only the save is skipped on `pull_request` and `merge_group`, where the cache wouldn't be restored anywhere anyway.

Motivating example: https://github.com/rootcause-rs/rootcause/actions/runs/26212825494/job/77127665519 — `Post Run Swatinem/rust-cache@v2` failed on `windows-latest, stable` while every build/test step passed. Root cause not confirmed; whatever it is, can still happen on `main`. This just stops us paying for it in the merge queue.