### PR TITLE
Strip redundant `rust` tag from in-source doc fence

### DIFF
--- a/src/hooks/report_creation.rs
+++ b/src/hooks/report_creation.rs
@@ -11,7 +11,7 @@
 //!
 //! 1. **Closures** - Simplest: Just return a value to attach
 //!
-//!    ```rust
+//!    ```
 //!    # use rootcause::hooks::Hooks;
 //!    Hooks::new().attachment_collector(|| "some data")
 //!    # ;


### PR DESCRIPTION
Doc-comment code fences default to Rust, so the `rust` language tag is redundant. #136 cleaned up the rest of these; this is the lone remaining occurrence.