### PR TITLE
Add nightly doc check CI job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,6 +67,24 @@ jobs:
       - name: Run cargo-deny
         uses: EmbarkStudios/cargo-deny-action@v2
 
+  nightly-doc-checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install rust nightly
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Run nightly doc checks
+        env:
+          RUSTDOCFLAGS: --cfg nightly_extra_checks
+        run: cargo doc --no-deps -p rootcause -p rootcause-backtrace -p rootcause-tracing --all-features
+
   miri:
     strategy:
       fail-fast: false

--- a/rootcause-backtrace/Cargo.toml
+++ b/rootcause-backtrace/Cargo.toml
@@ -20,3 +20,6 @@ unicode-ident = "1.0.24"
 
 # Internal dependencies
 rootcause = { path = "../", version = "=0.12.1" }
+
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(nightly_extra_checks)'] }

--- a/rootcause-backtrace/src/lib.rs
+++ b/rootcause-backtrace/src/lib.rs
@@ -7,6 +7,9 @@
     missing_copy_implementations,
     unused_doc_comments
 )]
+// Extra checks on nightly
+#![cfg_attr(nightly_extra_checks, feature(rustdoc_missing_doc_code_examples))]
+#![cfg_attr(nightly_extra_checks, forbid(rustdoc::missing_doc_code_examples))]
 
 //! Stack backtrace attachment collector for rootcause error reports.
 //!
@@ -171,6 +174,23 @@ pub struct Backtrace {
 }
 
 /// A single entry in a stack backtrace.
+///
+/// # Examples
+///
+/// ```
+/// use rootcause_backtrace::{Backtrace, BacktraceEntry, BacktraceFilter};
+///
+/// if let Some(bt) = Backtrace::capture(&BacktraceFilter::DEFAULT) {
+///     for entry in &bt.entries {
+///         match entry {
+///             BacktraceEntry::Frame(_) => { /* a real call */ }
+///             BacktraceEntry::OmittedFrames { count, skipped_crate } => {
+///                 println!("Omitted {count} frames from {skipped_crate}");
+///             }
+///         }
+///     }
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub enum BacktraceEntry {
     /// A normal stack frame.
@@ -188,6 +208,20 @@ pub enum BacktraceEntry {
 ///
 /// Represents one function call in the call stack, including symbol information
 /// and source location if available.
+///
+/// # Examples
+///
+/// ```
+/// use rootcause_backtrace::{Backtrace, BacktraceEntry, BacktraceFilter};
+///
+/// if let Some(bt) = Backtrace::capture(&BacktraceFilter::DEFAULT) {
+///     for entry in &bt.entries {
+///         if let BacktraceEntry::Frame(frame) = entry {
+///             println!("{}", frame.sym_demangled);
+///         }
+///     }
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub struct Frame {
     /// The demangled symbol name for this frame.
@@ -202,6 +236,22 @@ pub struct Frame {
 ///
 /// Contains the raw path and processed components for better display
 /// formatting.
+///
+/// # Examples
+///
+/// ```
+/// use rootcause_backtrace::{Backtrace, BacktraceEntry, BacktraceFilter};
+///
+/// if let Some(bt) = Backtrace::capture(&BacktraceFilter::DEFAULT) {
+///     for entry in &bt.entries {
+///         if let BacktraceEntry::Frame(frame) = entry {
+///             if let Some(path) = &frame.frame_path {
+///                 println!("{}", path.raw_path);
+///             }
+///         }
+///     }
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub struct FramePath {
     /// The raw file path from the debug information.
@@ -216,6 +266,26 @@ pub struct FramePath {
 ///
 /// This struct represents a decomposed file path where a known prefix
 /// has been identified and separated from the rest of the path.
+///
+/// # Examples
+///
+/// ```
+/// use rootcause_backtrace::{Backtrace, BacktraceEntry, BacktraceFilter};
+///
+/// if let Some(bt) = Backtrace::capture(&BacktraceFilter::DEFAULT) {
+///     for entry in &bt.entries {
+///         if let BacktraceEntry::Frame(frame) = entry {
+///             if let Some(prefix) = frame
+///                 .frame_path
+///                 .as_ref()
+///                 .and_then(|p| p.split_path.as_ref())
+///             {
+///                 println!("[{}] {}", prefix.prefix_kind, prefix.suffix);
+///             }
+///         }
+///     }
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub struct FramePrefix {
     /// The kind of prefix used to identify this prefix.
@@ -236,6 +306,22 @@ pub struct FramePrefix {
 }
 
 /// Handler for formatting [`Backtrace`] attachments.
+///
+/// The const generic `SHOW_FULL_PATH` controls whether file paths are shown
+/// in full or with common prefixes shortened.
+///
+/// # Examples
+///
+/// ```
+/// use rootcause::report_attachment::ReportAttachment;
+/// use rootcause_backtrace::{Backtrace, BacktraceFilter, BacktraceHandler};
+///
+/// let backtrace = Backtrace::capture(&BacktraceFilter::DEFAULT)
+///     .unwrap_or(Backtrace { entries: Vec::new(), total_omitted_frames: 0 });
+///
+/// // SHOW_FULL_PATH = false: shortened paths
+/// let _ = ReportAttachment::new_sendsync_custom::<BacktraceHandler<false>>(backtrace);
+/// ```
 #[derive(Copy, Clone)]
 pub struct BacktraceHandler<const SHOW_FULL_PATH: bool>;
 
@@ -660,6 +746,18 @@ const ROOTCAUSE_MATCHER: Option<(&str, usize)> =
 
 impl Backtrace {
     /// Captures the current stack backtrace, applying optional filtering.
+    ///
+    /// Returns `None` if a backtrace could not be captured.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rootcause_backtrace::{Backtrace, BacktraceFilter};
+    ///
+    /// if let Some(bt) = Backtrace::capture(&BacktraceFilter::DEFAULT) {
+    ///     println!("Captured {} frames", bt.entries.len());
+    /// }
+    /// ```
     pub fn capture(filter: &BacktraceFilter) -> Option<Self> {
         let mut initial_filtering = !filter.skipped_initial_crates.is_empty();
         let mut entries: Vec<BacktraceEntry> = Vec::new();

--- a/rootcause-tracing/Cargo.toml
+++ b/rootcause-tracing/Cargo.toml
@@ -27,3 +27,6 @@ tracing = { version = "0.1.44", default-features = true, features = [
 tracing-subscriber = { version = "0.3.23", default-features = false, features = [
   "fmt",
 ] }
+
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(nightly_extra_checks)'] }

--- a/rootcause-tracing/src/lib.rs
+++ b/rootcause-tracing/src/lib.rs
@@ -7,6 +7,9 @@
     missing_copy_implementations,
     unused_doc_comments
 )]
+// Extra checks on nightly
+#![cfg_attr(nightly_extra_checks, feature(rustdoc_missing_doc_code_examples))]
+#![cfg_attr(nightly_extra_checks, forbid(rustdoc::missing_doc_code_examples))]
 
 //! Tracing span capture for rootcause error reports.
 //!
@@ -102,6 +105,17 @@ use tracing_subscriber::{
 };
 
 /// Handler for formatting [`Span`] attachments.
+///
+/// # Examples
+///
+/// ```
+/// use rootcause::report_attachment::ReportAttachment;
+/// use rootcause_tracing::SpanHandler;
+/// use tracing::Span;
+///
+/// let span = Span::current();
+/// let _ = ReportAttachment::new_sendsync_custom::<SpanHandler>(span);
+/// ```
 #[derive(Copy, Clone)]
 pub struct SpanHandler;
 


### PR DESCRIPTION
Adds a `nightly-doc-checks` job that runs rustdoc on nightly with `RUSTDOCFLAGS='--cfg nightly_extra_checks'`, enabling `forbid(rustdoc::missing_doc_code_examples)` on the three publishable crates.

The lint was previously only configured in the `rootcause` crate. This extends the same cfg gate to `rootcause-backtrace` and `rootcause-tracing` and adds the missing examples it surfaces:

- **rootcause-backtrace**: `BacktraceEntry`, `Frame`, `FramePath`, `FramePrefix`, `BacktraceHandler`, `Backtrace::capture`
- **rootcause-tracing**: `SpanHandler`

`rootcause-internals` is deliberately excluded; it's the internal implementation crate.

Without this in CI, the lint can only be checked manually, so regressions slip in — e.g. #136 was found to be missing two examples only by running this command locally.