### PR TITLE
Fix stale docs about default `preferred_formatting_style` behavior

### DIFF
--- a/rootcause-internals/src/handlers.rs
+++ b/rootcause-internals/src/handlers.rs
@@ -38,7 +38,7 @@
 ///
 /// - [`preferred_formatting_style`](ContextHandler::preferred_formatting_style):
 ///   Specifies whether to use display or debug formatting when embedded in a report.
-///   The default implementation always prefers display formatting.
+///   The default implementation matches the formatting of the report itself.
 ///
 /// # Examples
 ///
@@ -258,8 +258,8 @@ pub trait ContextHandler<C>: 'static {
 ///
 /// - [`preferred_formatting_style`](AttachmentHandler::preferred_formatting_style):
 ///   Specifies formatting preferences including placement (inline/appendix) and
-///   whether to use display or debug formatting. The default implementation prefers
-///   inline display formatting.
+///   whether to use display or debug formatting. The default implementation uses
+///   inline placement with the same formatting function as the report itself.
 ///
 /// # Examples
 ///

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -27,12 +27,12 @@
 //! [`AttachmentHandler::preferred_formatting_style`] methods allow handlers to
 //! specify whether they prefer [`Display`](core::fmt::Display) or
 //! [`Debug`](core::fmt::Debug) formatting when shown in a report. The default
-//! behavior is to always use `Display` formatting, regardless of how the report
-//! itself is being formatted.
+//! behavior is to match how the report itself is being formatted: when the
+//! report is displayed with `{}` the `display` method is used, and when it is
+//! debug-formatted with `{:?}` the `debug` method is used.
 //!
 //! All built-in handlers ([`Error`], [`Display`], [`struct@Debug`], [`Any`])
-//! use this default behavior, which means they use their `display` method even
-//! when the report is being debug-formatted with `{:?}`.
+//! use this default behavior.
 //!
 //! ## 2. Attachment Placement
 //!
@@ -266,9 +266,10 @@ where
 /// assert!(display_output.contains("InternalState"));
 /// assert!(!display_output.contains("connection_count")); // Details not shown
 ///
-/// // Debug formatting also uses the handler's Display method (the default behavior)
+/// // Debug formatting uses the handler's `debug` method, which delegates to the
+/// // type's `Debug` impl — so the full state is shown.
 /// let debug_output = format!("{:?}", report);
-/// assert!(debug_output.contains("InternalState"));
+/// assert!(debug_output.contains("connection_count"));
 /// ```
 #[derive(Copy, Clone)]
 pub struct Debug;


### PR DESCRIPTION
Fixes #166.

Since #116, the default `preferred_formatting_style` impl matches the
report's formatting function rather than always returning `Display`. A
few rustdoc summaries (module docs in `src/handlers.rs`, trait
optional-methods bullets in `rootcause-internals`) and the `Debug`
handler's doctest still described the old behavior.

The `Debug` doctest's `debug_output` assertion only checked for the
type name, which appears under either behavior — strengthened it to
check for a field name so the example actually demonstrates that
debug-formatting a `Report` reaches the handler's `debug` method.