### PR TITLE
Add `&dyn Any` accessors for contexts and attachments (#151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `current_context_as_any` / `current_context_as_any_mut` on `Report`/`ReportRef`/`ReportMut` and `inner_as_any` / `inner_as_any_mut` on `ReportAttachment`/`ReportAttachmentRef`/`ReportAttachmentMut` for `&dyn Any` access to contexts and attachments [#151](https://github.com/rootcause-rs/rootcause/issues/151).
 - Added a compatibility module for error-stack v0.7 [#169](https://github.com/rootcause-rs/rootcause/pull/169).
 - Implement `Deref<Target = dyn Error>` and `AsRef<dyn Error>` for `Report`, `ReportRef` and `ReportMut`. `Report<_, _, SendSync>` targets `dyn Error + Send + Sync`. Splitting `Deref` by thread-safety marker may break type inference at call sites of `Report::new_custom` / `Report::new`; use `new_sendsync_custom` / `new_local_custom` or explicit annotations to fix. [#147](https://github.com/rootcause-rs/rootcause/pull/147), [#149](https://github.com/rootcause-rs/rootcause/pull/149)
 - Doc examples for nearly all public functions [#136](https://github.com/rootcause-rs/rootcause/pull/136).

--- a/rootcause-internals/src/attachment/raw.rs
+++ b/rootcause-internals/src/attachment/raw.rs
@@ -23,7 +23,10 @@
 //! attachments.
 
 use alloc::boxed::Box;
-use core::{any::TypeId, ptr::NonNull};
+use core::{
+    any::{Any, TypeId},
+    ptr::NonNull,
+};
 
 use crate::{
     attachment::data::AttachmentData,
@@ -256,6 +259,22 @@ impl<'a> RawAttachmentRef<'a> {
         }
     }
 
+    /// Returns a [`&dyn Any`](Any) view of the attachment.
+    ///
+    /// The returned reference can be downcast using
+    /// `<dyn Any>::downcast_ref`.
+    #[inline]
+    pub fn attachment_as_any(self) -> &'a (dyn Any + 'static) {
+        let vtable = self.vtable();
+        // SAFETY:
+        // 1. The vtable returned by `self.vtable()` is guaranteed to match the data in
+        //    the `AttachmentData`.
+        unsafe {
+            // @add-unsafe-context: AttachmentData
+            vtable.attachment_as_any(self)
+        }
+    }
+
     /// The formatting style preferred by the attachment when formatted as part
     /// of a report.
     ///
@@ -376,6 +395,23 @@ impl<'a> RawAttachmentMut<'a> {
             //    `self` while the returned reference exists
             ptr: self.ptr,
             _marker: core::marker::PhantomData,
+        }
+    }
+
+    /// Consumes this [`RawAttachmentMut`] and returns a [`&mut dyn Any`](Any)
+    /// view of the attachment with the same lifetime.
+    ///
+    /// The returned reference can be downcast using
+    /// `<dyn Any>::downcast_mut`.
+    #[inline]
+    pub fn into_attachment_as_any_mut(self) -> &'a mut (dyn Any + 'static) {
+        let vtable = self.as_ref().vtable();
+        // SAFETY:
+        // 1. The vtable returned by `self.as_ref().vtable()` is guaranteed to match the
+        //    data in the `AttachmentData`.
+        unsafe {
+            // @add-unsafe-context: AttachmentData
+            vtable.attachment_as_any_mut(self)
         }
     }
 
@@ -583,5 +619,24 @@ mod tests {
         static_assertions::assert_not_impl_any!(RawAttachment: Send, Sync);
         static_assertions::assert_not_impl_any!(RawAttachmentRef<'_>: Send, Sync);
         static_assertions::assert_not_impl_any!(RawAttachmentMut<'_>: Send, Sync);
+    }
+
+    #[test]
+    fn test_raw_attachment_as_any() {
+        let attachment = RawAttachment::new::<i32, HandlerI32>(42);
+        let any = attachment.as_ref().attachment_as_any();
+        assert_eq!(any.downcast_ref::<i32>(), Some(&42));
+        assert!(any.downcast_ref::<String>().is_none());
+    }
+
+    #[test]
+    fn test_raw_attachment_as_any_mut() {
+        let mut attachment = RawAttachment::new::<i32, HandlerI32>(41);
+        let any = attachment.as_mut().into_attachment_as_any_mut();
+        *any.downcast_mut::<i32>().unwrap() += 1;
+        assert_eq!(
+            unsafe { *attachment.as_ref().attachment_downcast_unchecked::<i32>() },
+            42
+        );
     }
 }

--- a/rootcause-internals/src/attachment/vtable.rs
+++ b/rootcause-internals/src/attachment/vtable.rs
@@ -18,12 +18,15 @@
 
 use alloc::boxed::Box;
 use core::{
-    any::{self, TypeId},
+    any::{self, Any, TypeId},
     ptr::NonNull,
 };
 
 use crate::{
-    attachment::{data::AttachmentData, raw::RawAttachmentRef},
+    attachment::{
+        data::AttachmentData,
+        raw::{RawAttachmentMut, RawAttachmentRef},
+    },
     handlers::{AttachmentFormattingStyle, AttachmentHandler, FormattingFunction},
     util::Erased,
 };
@@ -60,6 +63,10 @@ pub(crate) struct AttachmentVtable {
     /// part of a report.
     preferred_formatting_style:
         unsafe fn(RawAttachmentRef<'_>, FormattingFunction) -> AttachmentFormattingStyle,
+    /// Returns a `&dyn Any` view of the attachment.
+    attachment_as_any: unsafe fn(RawAttachmentRef<'_>) -> &(dyn Any + 'static),
+    /// Returns a `&mut dyn Any` view of the attachment.
+    attachment_as_any_mut: unsafe fn(RawAttachmentMut<'_>) -> &mut (dyn Any + 'static),
 }
 
 impl AttachmentVtable {
@@ -75,6 +82,8 @@ impl AttachmentVtable {
                 display: display::<A, H>,
                 debug: debug::<A, H>,
                 preferred_formatting_style: preferred_formatting_style::<A, H>,
+                attachment_as_any: attachment_as_any::<A>,
+                attachment_as_any_mut: attachment_as_any_mut::<A>,
             }
         }
     }
@@ -210,6 +219,58 @@ impl AttachmentVtable {
             (self.preferred_formatting_style)(ptr, report_formatting_function)
         }
     }
+
+    /// Returns a `&dyn Any` reference to the attachment using the function
+    /// pointer stored in this [`AttachmentVtable`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure:
+    ///
+    /// 1. This [`AttachmentVtable`] must be a vtable for the attachment type
+    ///    stored in the [`RawAttachmentRef`].
+    #[inline]
+    pub(super) unsafe fn attachment_as_any<'a>(
+        &self,
+        ptr: RawAttachmentRef<'a>,
+    ) -> &'a (dyn Any + 'static) {
+        // SAFETY: We know that the `self.attachment_as_any` field points to the
+        // function `attachment_as_any::<A>` below. That function's safety
+        // requirements are upheld:
+        // 1. Guaranteed by the caller
+        unsafe {
+            // @add-unsafe-context: attachment_as_any
+            // @add-unsafe-context: RawAttachmentRef
+            // @add-unsafe-context: AttachmentData
+            (self.attachment_as_any)(ptr)
+        }
+    }
+
+    /// Returns a `&mut dyn Any` reference to the attachment using the function
+    /// pointer stored in this [`AttachmentVtable`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure:
+    ///
+    /// 1. This [`AttachmentVtable`] must be a vtable for the attachment type
+    ///    stored in the [`RawAttachmentMut`].
+    #[inline]
+    pub(super) unsafe fn attachment_as_any_mut<'a>(
+        &self,
+        ptr: RawAttachmentMut<'a>,
+    ) -> &'a mut (dyn Any + 'static) {
+        // SAFETY: We know that the `self.attachment_as_any_mut` field points to
+        // the function `attachment_as_any_mut::<A>` below. That function's
+        // safety requirements are upheld:
+        // 1. Guaranteed by the caller
+        unsafe {
+            // @add-unsafe-context: attachment_as_any_mut
+            // @add-unsafe-context: RawAttachmentMut
+            // @add-unsafe-context: AttachmentData
+            (self.attachment_as_any_mut)(ptr)
+        }
+    }
 }
 
 /// Drops the [`Box<AttachmentData<A>>`] instance pointed to by this pointer.
@@ -292,6 +353,40 @@ unsafe fn preferred_formatting_style<A: 'static, H: AttachmentHandler<A>>(
     // 1. Guaranteed by the caller
     let attachment: &A = unsafe { ptr.attachment_downcast_unchecked::<A>() };
     H::preferred_formatting_style(attachment, report_formatting_function)
+}
+
+/// Returns a `&dyn Any` view of the attachment.
+///
+/// # Safety
+///
+/// The caller must ensure:
+///
+/// 1. The type `A` matches the actual attachment type stored in the
+///    [`AttachmentData`]
+unsafe fn attachment_as_any<'a, A: 'static>(
+    ptr: RawAttachmentRef<'a>,
+) -> &'a (dyn Any + 'static) {
+    // SAFETY:
+    // 1. Guaranteed by the caller
+    let attachment: &A = unsafe { ptr.attachment_downcast_unchecked::<A>() };
+    attachment as &(dyn Any + 'static)
+}
+
+/// Returns a `&mut dyn Any` view of the attachment.
+///
+/// # Safety
+///
+/// The caller must ensure:
+///
+/// 1. The type `A` matches the actual attachment type stored in the
+///    [`AttachmentData`]
+unsafe fn attachment_as_any_mut<'a, A: 'static>(
+    ptr: RawAttachmentMut<'a>,
+) -> &'a mut (dyn Any + 'static) {
+    // SAFETY:
+    // 1. Guaranteed by the caller
+    let attachment: &mut A = unsafe { ptr.into_attachment_downcast_unchecked::<A>() };
+    attachment as &mut (dyn Any + 'static)
 }
 
 #[cfg(test)]

--- a/rootcause-internals/src/attachment/vtable.rs
+++ b/rootcause-internals/src/attachment/vtable.rs
@@ -363,9 +363,7 @@ unsafe fn preferred_formatting_style<A: 'static, H: AttachmentHandler<A>>(
 ///
 /// 1. The type `A` matches the actual attachment type stored in the
 ///    [`AttachmentData`]
-unsafe fn attachment_as_any<'a, A: 'static>(
-    ptr: RawAttachmentRef<'a>,
-) -> &'a (dyn Any + 'static) {
+unsafe fn attachment_as_any<'a, A: 'static>(ptr: RawAttachmentRef<'a>) -> &'a (dyn Any + 'static) {
     // SAFETY:
     // 1. Guaranteed by the caller
     let attachment: &A = unsafe { ptr.attachment_downcast_unchecked::<A>() };

--- a/rootcause-internals/src/report/raw.rs
+++ b/rootcause-internals/src/report/raw.rs
@@ -30,7 +30,10 @@
 //! - Thread-safe sharing when the context type is `Send + Sync`
 
 use alloc::vec::Vec;
-use core::{any::TypeId, ptr::NonNull};
+use core::{
+    any::{Any, TypeId},
+    ptr::NonNull,
+};
 
 use crate::{
     attachment::RawAttachment,
@@ -341,6 +344,22 @@ impl<'a> RawReportRef<'a> {
         }
     }
 
+    /// Returns a [`&dyn Any`](Any) view of the context.
+    ///
+    /// The returned reference can be downcast using
+    /// `<dyn Any>::downcast_ref`.
+    #[inline]
+    pub fn context_as_any(self) -> &'a (dyn Any + 'static) {
+        let vtable = self.vtable();
+        // SAFETY:
+        // 1. The vtable returned by `self.vtable()` is guaranteed to match the data in
+        //    the `ReportData`.
+        unsafe {
+            // @add-unsafe-context: ReportData
+            vtable.context_as_any(self)
+        }
+    }
+
     /// Gets the strong_count of the inner [`triomphe::Arc`].
     #[inline]
     pub fn strong_count(self) -> usize {
@@ -476,6 +495,23 @@ impl<'a> RawReportMut<'a> {
     #[inline]
     pub(super) fn into_mut_ptr(self) -> *mut ReportData<Erased> {
         self.ptr.as_ptr()
+    }
+
+    /// Consumes this [`RawReportMut`] and returns a [`&mut dyn Any`](Any) view
+    /// of the context with the same lifetime.
+    ///
+    /// The returned reference can be downcast using
+    /// `<dyn Any>::downcast_mut`.
+    #[inline]
+    pub fn into_context_as_any_mut(self) -> &'a mut (dyn Any + 'static) {
+        let vtable = self.as_ref().vtable();
+        // SAFETY:
+        // 1. The vtable returned by `self.as_ref().vtable()` is guaranteed to match the
+        //    data in the `ReportData`.
+        unsafe {
+            // @add-unsafe-context: ReportData
+            vtable.context_as_any_mut(self)
+        }
     }
 }
 
@@ -866,5 +902,28 @@ mod tests {
         static_assertions::assert_not_impl_any!(RawReport: Send, Sync);
         static_assertions::assert_not_impl_any!(RawReportRef<'_>: Send, Sync);
         static_assertions::assert_not_impl_any!(RawReportMut<'_>: Send, Sync);
+    }
+
+    #[test]
+    fn test_raw_report_context_as_any() {
+        let report = RawReport::new::<i32, HandlerI32>(42, vec![], vec![]);
+        let any = report.as_ref().context_as_any();
+        assert_eq!(any.downcast_ref::<i32>(), Some(&42));
+        assert!(any.downcast_ref::<String>().is_none());
+    }
+
+    #[test]
+    fn test_raw_report_context_as_any_mut() {
+        let mut report = RawReport::new::<i32, HandlerI32>(41, vec![], vec![]);
+
+        // SAFETY: We have unique ownership of the report
+        let report_mut = unsafe { report.as_mut() };
+        let any = report_mut.into_context_as_any_mut();
+        *any.downcast_mut::<i32>().unwrap() += 1;
+
+        assert_eq!(
+            unsafe { report.as_ref().context_downcast_unchecked::<i32>() },
+            &42
+        );
     }
 }

--- a/rootcause-internals/src/report/vtable.rs
+++ b/rootcause-internals/src/report/vtable.rs
@@ -545,9 +545,7 @@ unsafe fn context_as_any<'a, C: 'static>(ptr: RawReportRef<'a>) -> &'a (dyn Any 
 /// The caller must ensure:
 ///
 /// 1. The type `C` matches the actual context type stored in the [`ReportData`]
-unsafe fn context_as_any_mut<'a, C: 'static>(
-    ptr: RawReportMut<'a>,
-) -> &'a mut (dyn Any + 'static) {
+unsafe fn context_as_any_mut<'a, C: 'static>(ptr: RawReportMut<'a>) -> &'a mut (dyn Any + 'static) {
     // SAFETY:
     // 1. Guaranteed by the caller
     let context: &mut C = unsafe { ptr.into_context_downcast_unchecked::<C>() };

--- a/rootcause-internals/src/report/vtable.rs
+++ b/rootcause-internals/src/report/vtable.rs
@@ -17,7 +17,7 @@
 //! with specific types `C` and `H` at compile time.
 
 use core::{
-    any::{self, TypeId},
+    any::{self, Any, TypeId},
     ptr::NonNull,
 };
 
@@ -25,7 +25,7 @@ use crate::{
     handlers::{ContextFormattingStyle, ContextHandler, FormattingFunction},
     report::{
         data::ReportData,
-        raw::{RawReport, RawReportRef},
+        raw::{RawReport, RawReportMut, RawReportRef},
     },
     util::Erased,
 };
@@ -74,6 +74,10 @@ pub(crate) struct ReportVtable {
     /// of a report.
     preferred_context_formatting_style:
         unsafe fn(RawReportRef<'_>, FormattingFunction) -> ContextFormattingStyle,
+    /// Returns a `&dyn Any` view of the context.
+    context_as_any: unsafe fn(RawReportRef<'_>) -> &(dyn Any + 'static),
+    /// Returns a `&mut dyn Any` view of the context.
+    context_as_any_mut: unsafe fn(RawReportMut<'_>) -> &mut (dyn Any + 'static),
 }
 
 impl ReportVtable {
@@ -92,6 +96,8 @@ impl ReportVtable {
                 display: display::<C, H>,
                 debug: debug::<C, H>,
                 preferred_context_formatting_style: preferred_context_formatting_style::<C, H>,
+                context_as_any: context_as_any::<C>,
+                context_as_any_mut: context_as_any_mut::<C>,
             }
         }
     }
@@ -311,6 +317,58 @@ impl ReportVtable {
             (self.preferred_context_formatting_style)(ptr, report_formatting_function)
         }
     }
+
+    /// Returns a `&dyn Any` reference to the context using the function pointer
+    /// stored in this [`ReportVtable`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure:
+    ///
+    /// 1. This [`ReportVtable`] must be a vtable for the context type stored in
+    ///    the [`RawReportRef`].
+    #[inline]
+    pub(super) unsafe fn context_as_any<'a>(
+        &self,
+        ptr: RawReportRef<'a>,
+    ) -> &'a (dyn Any + 'static) {
+        // SAFETY: We know that `self.context_as_any` points to the function
+        // `context_as_any::<C>` below. That function's safety requirements are
+        // upheld:
+        // 1. Guaranteed by the caller
+        unsafe {
+            // @add-unsafe-context: context_as_any
+            // @add-unsafe-context: RawReportRef
+            // @add-unsafe-context: ReportData
+            (self.context_as_any)(ptr)
+        }
+    }
+
+    /// Returns a `&mut dyn Any` reference to the context using the function
+    /// pointer stored in this [`ReportVtable`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure:
+    ///
+    /// 1. This [`ReportVtable`] must be a vtable for the context type stored in
+    ///    the [`RawReportMut`].
+    #[inline]
+    pub(super) unsafe fn context_as_any_mut<'a>(
+        &self,
+        ptr: RawReportMut<'a>,
+    ) -> &'a mut (dyn Any + 'static) {
+        // SAFETY: We know that `self.context_as_any_mut` points to the function
+        // `context_as_any_mut::<C>` below. That function's safety requirements
+        // are upheld:
+        // 1. Guaranteed by the caller
+        unsafe {
+            // @add-unsafe-context: context_as_any_mut
+            // @add-unsafe-context: RawReportMut
+            // @add-unsafe-context: ReportData
+            (self.context_as_any_mut)(ptr)
+        }
+    }
 }
 
 /// Drops the [`triomphe::Arc<ReportData<C>>`] instance pointed to by this
@@ -464,6 +522,36 @@ unsafe fn preferred_context_formatting_style<C: 'static, H: ContextHandler<C>>(
     // 1. Guaranteed by the caller
     let context: &C = unsafe { ptr.context_downcast_unchecked::<C>() };
     H::preferred_formatting_style(context, report_formatting_function)
+}
+
+/// Returns a `&dyn Any` view of the context.
+///
+/// # Safety
+///
+/// The caller must ensure:
+///
+/// 1. The type `C` matches the actual context type stored in the [`ReportData`]
+unsafe fn context_as_any<'a, C: 'static>(ptr: RawReportRef<'a>) -> &'a (dyn Any + 'static) {
+    // SAFETY:
+    // 1. Guaranteed by the caller
+    let context: &C = unsafe { ptr.context_downcast_unchecked::<C>() };
+    context as &(dyn Any + 'static)
+}
+
+/// Returns a `&mut dyn Any` view of the context.
+///
+/// # Safety
+///
+/// The caller must ensure:
+///
+/// 1. The type `C` matches the actual context type stored in the [`ReportData`]
+unsafe fn context_as_any_mut<'a, C: 'static>(
+    ptr: RawReportMut<'a>,
+) -> &'a mut (dyn Any + 'static) {
+    // SAFETY:
+    // 1. Guaranteed by the caller
+    let context: &mut C = unsafe { ptr.into_context_downcast_unchecked::<C>() };
+    context as &mut (dyn Any + 'static)
 }
 
 #[cfg(test)]

--- a/src/report/mut_.rs
+++ b/src/report/mut_.rs
@@ -1,4 +1,4 @@
-use core::any::TypeId;
+use core::any::{Any, TypeId};
 
 use rootcause_internals::handlers::{ContextFormattingStyle, FormattingFunction};
 
@@ -782,6 +782,82 @@ impl<'a, C: ?Sized, T> ReportMut<'a, C, T> {
     #[must_use]
     pub fn current_context_handler_type_id(&self) -> TypeId {
         self.as_raw_ref().context_handler_type_id()
+    }
+
+    /// Returns a [`&dyn Any`](Any) view of the current context.
+    ///
+    /// This is the most general accessor for the current context: it works
+    /// whether the context type `C` is known at compile time or erased to
+    /// [`Dynamic`]. The returned reference can be downcast using
+    /// `<dyn Any>::downcast_ref` and interoperates with
+    /// any code that accepts `&dyn Any`.
+    ///
+    /// For mutable access, use [`current_context_as_any_mut`] or
+    /// [`into_current_context_as_any_mut`].
+    ///
+    /// [`Dynamic`]: crate::markers::Dynamic
+    /// [`current_context_as_any_mut`]: ReportMut::current_context_as_any_mut
+    /// [`into_current_context_as_any_mut`]: ReportMut::into_current_context_as_any_mut
+    ///
+    /// # Examples
+    /// ```
+    /// # use rootcause::prelude::*;
+    /// # use core::any::Any;
+    /// # struct MyError;
+    /// # let mut report = report!(MyError);
+    /// let report_mut = report.as_mut();
+    /// let any: &dyn Any = report_mut.current_context_as_any();
+    /// assert!(any.is::<MyError>());
+    /// ```
+    #[must_use]
+    pub fn current_context_as_any(&self) -> &(dyn Any + 'static) {
+        self.as_raw_ref().context_as_any()
+    }
+
+    /// Returns a [`&mut dyn Any`](Any) view of the current context.
+    ///
+    /// The returned reference can be downcast using
+    /// `<dyn Any>::downcast_mut`.
+    ///
+    /// # Examples
+    /// ```
+    /// # use rootcause::prelude::*;
+    /// # use core::any::Any;
+    /// # let mut report: Report<String> = report!("An error occurred".to_string());
+    /// let mut report_mut = report.as_mut();
+    /// let any: &mut dyn Any = report_mut.current_context_as_any_mut();
+    /// if let Some(s) = any.downcast_mut::<String>() {
+    ///     s.push_str(" and that's bad");
+    /// }
+    /// ```
+    #[must_use]
+    pub fn current_context_as_any_mut(&mut self) -> &mut (dyn Any + 'static) {
+        self.as_mut().into_current_context_as_any_mut()
+    }
+
+    /// Consumes the [`ReportMut`] and returns a [`&mut dyn Any`](Any) view of
+    /// the current context with the same lifetime.
+    ///
+    /// The returned reference can be downcast using
+    /// `<dyn Any>::downcast_mut`.
+    ///
+    /// # Examples
+    /// ```
+    /// # use rootcause::prelude::*;
+    /// # use core::any::Any;
+    /// # let mut report: Report<String> = report!("An error occurred".to_string());
+    /// let report_mut = report.as_mut();
+    /// let any: &mut dyn Any = report_mut.into_current_context_as_any_mut();
+    /// if let Some(s) = any.downcast_mut::<String>() {
+    ///     s.push_str(" and that's bad");
+    /// }
+    /// ```
+    #[must_use]
+    pub fn into_current_context_as_any_mut(self) -> &'a mut (dyn Any + 'static) {
+        // SAFETY:
+        // 1. We are not adding any objects
+        let raw = unsafe { self.into_raw_mut() };
+        raw.into_context_as_any_mut()
     }
 
     /// Returns the error source if the context implements [`Error`].

--- a/src/report/owned.rs
+++ b/src/report/owned.rs
@@ -1,4 +1,4 @@
-use core::any::TypeId;
+use core::any::{Any, TypeId};
 
 use rootcause_internals::{
     RawReport,
@@ -763,6 +763,29 @@ impl<C: ?Sized, T> Report<C, Mutable, T> {
     pub fn attachments_mut(&mut self) -> &mut ReportAttachments<T> {
         self.as_mut().into_attachments_mut()
     }
+
+    /// Returns a [`&mut dyn Any`](Any) view of the current context.
+    ///
+    /// This works whether the context type `C` is known at compile time or
+    /// erased to [`Dynamic`]. The returned reference can be downcast using
+    /// `<dyn Any>::downcast_mut`.
+    ///
+    /// [`Dynamic`]: crate::markers::Dynamic
+    ///
+    /// # Examples
+    /// ```
+    /// # use rootcause::prelude::*;
+    /// # use core::any::Any;
+    /// let mut report: Report<String> = report!(String::from("An error occurred"));
+    /// let any: &mut dyn Any = report.current_context_as_any_mut();
+    /// if let Some(s) = any.downcast_mut::<String>() {
+    ///     s.push_str(" and that's bad");
+    /// }
+    /// ```
+    #[must_use]
+    pub fn current_context_as_any_mut(&mut self) -> &mut (dyn Any + 'static) {
+        self.as_mut().into_current_context_as_any_mut()
+    }
 }
 
 impl<C: ?Sized, O, T> Report<C, O, T> {
@@ -1317,6 +1340,35 @@ impl<C: ?Sized, O, T> Report<C, O, T> {
     #[must_use]
     pub fn current_context_handler_type_id(&self) -> TypeId {
         self.as_uncloneable_ref().current_context_handler_type_id()
+    }
+
+    /// Returns a [`&dyn Any`](Any) view of the current context.
+    ///
+    /// This is the most general accessor for the current context: it works
+    /// whether the context type `C` is known at compile time or erased to
+    /// [`Dynamic`]. The returned reference can be downcast using
+    /// `<dyn Any>::downcast_ref` and interoperates with
+    /// any code that accepts `&dyn Any`.
+    ///
+    /// [`Dynamic`]: crate::markers::Dynamic
+    ///
+    /// # Examples
+    /// ```
+    /// # use rootcause::prelude::*;
+    /// # use core::any::Any;
+    /// # struct MyError;
+    /// let report: Report<MyError> = report!(MyError);
+    /// let any: &dyn Any = report.current_context_as_any();
+    /// assert!(any.is::<MyError>());
+    ///
+    /// // Also works for Dynamic reports
+    /// let report: Report = report.into_dynamic();
+    /// let any: &dyn Any = report.current_context_as_any();
+    /// assert!(any.is::<MyError>());
+    /// ```
+    #[must_use]
+    pub fn current_context_as_any(&self) -> &(dyn Any + 'static) {
+        self.as_uncloneable_ref().current_context_as_any()
     }
 
     /// Returns the error source if the context implements [`Error`].

--- a/src/report/ref_.rs
+++ b/src/report/ref_.rs
@@ -1,5 +1,5 @@
 use alloc::vec;
-use core::any::TypeId;
+use core::any::{Any, TypeId};
 
 use rootcause_internals::handlers::{ContextFormattingStyle, FormattingFunction};
 
@@ -632,6 +632,34 @@ impl<'a, C: ?Sized, O, T> ReportRef<'a, C, O, T> {
     #[must_use]
     pub fn current_context_type_name(self) -> &'static str {
         self.as_raw_ref().context_type_name()
+    }
+
+    /// Returns a [`&dyn Any`](Any) view of the current context.
+    ///
+    /// This is the most general accessor for the current context: it works
+    /// whether the context type `C` is known at compile time or erased to
+    /// [`Dynamic`]. The returned reference can be downcast using
+    /// `<dyn Any>::downcast_ref` and interoperates with
+    /// any code that accepts `&dyn Any`.
+    ///
+    /// # Examples
+    /// ```
+    /// # use rootcause::{prelude::*, ReportRef, markers::Dynamic};
+    /// # use core::any::Any;
+    /// # struct MyError;
+    /// # let report = report!(MyError).into_cloneable();
+    /// let report_ref: ReportRef<'_, MyError> = report.as_ref();
+    /// let any: &dyn Any = report_ref.current_context_as_any();
+    /// assert!(any.is::<MyError>());
+    ///
+    /// // Also works for Dynamic reports
+    /// let dyn_ref: ReportRef<'_, Dynamic> = report_ref.into_dynamic();
+    /// let any: &dyn Any = dyn_ref.current_context_as_any();
+    /// assert_eq!(any.downcast_ref::<MyError>().map(|_| ()), Some(()));
+    /// ```
+    #[must_use]
+    pub fn current_context_as_any(self) -> &'a (dyn Any + 'static) {
+        self.as_raw_ref().context_as_any()
     }
 
     /// Returns the [`TypeId`] of the handler used for the current context.

--- a/src/report_attachment/mut_.rs
+++ b/src/report_attachment/mut_.rs
@@ -1,4 +1,4 @@
-use core::any::TypeId;
+use core::any::{Any, TypeId};
 
 use rootcause_internals::handlers::{AttachmentFormattingStyle, FormattingFunction};
 
@@ -384,6 +384,76 @@ impl<'a, A: ?Sized> ReportAttachmentMut<'a, A> {
     #[must_use]
     pub fn inner_handler_type_id(&self) -> TypeId {
         self.as_raw_ref().attachment_handler_type_id()
+    }
+
+    /// Returns a [`&dyn Any`](Any) view of the inner attachment.
+    ///
+    /// This works whether the attachment type `A` is known at compile time or
+    /// erased to [`Dynamic`]. The returned reference can be downcast using
+    /// `<dyn Any>::downcast_ref`.
+    ///
+    /// # Examples
+    /// ```
+    /// # use rootcause::{prelude::*, report_attachment::ReportAttachment};
+    /// # use core::any::Any;
+    /// let mut attachment = ReportAttachment::new_sendsync(42i32);
+    /// let attachment_mut = attachment.as_mut();
+    /// let any: &dyn Any = attachment_mut.inner_as_any();
+    /// assert_eq!(any.downcast_ref::<i32>(), Some(&42));
+    /// ```
+    #[must_use]
+    pub fn inner_as_any(&self) -> &(dyn Any + 'static) {
+        self.as_raw_ref().attachment_as_any()
+    }
+
+    /// Returns a [`&mut dyn Any`](Any) view of the inner attachment.
+    ///
+    /// The returned reference can be downcast using
+    /// `<dyn Any>::downcast_mut`.
+    ///
+    /// # Examples
+    /// ```
+    /// # use rootcause::{prelude::*, report_attachment::ReportAttachment};
+    /// # use core::any::Any;
+    /// let mut attachment = ReportAttachment::new_sendsync(41i32);
+    /// {
+    ///     let mut attachment_mut = attachment.as_mut();
+    ///     let any: &mut dyn Any = attachment_mut.inner_as_any_mut();
+    ///     if let Some(n) = any.downcast_mut::<i32>() {
+    ///         *n += 1;
+    ///     }
+    /// }
+    /// assert_eq!(attachment.format_inner().to_string(), "42");
+    /// ```
+    #[must_use]
+    pub fn inner_as_any_mut(&mut self) -> &mut (dyn Any + 'static) {
+        self.as_mut().into_inner_as_any_mut()
+    }
+
+    /// Consumes the [`ReportAttachmentMut`] and returns a [`&mut dyn Any`](Any)
+    /// view of the inner attachment with the same lifetime.
+    ///
+    /// The returned reference can be downcast using
+    /// `<dyn Any>::downcast_mut`.
+    ///
+    /// # Examples
+    /// ```
+    /// # use rootcause::{prelude::*, report_attachment::ReportAttachment};
+    /// # use core::any::Any;
+    /// let mut attachment = ReportAttachment::new_sendsync(41i32);
+    /// {
+    ///     let attachment_mut = attachment.as_mut();
+    ///     let any: &mut dyn Any = attachment_mut.into_inner_as_any_mut();
+    ///     if let Some(n) = any.downcast_mut::<i32>() {
+    ///         *n += 1;
+    ///     }
+    /// }
+    /// assert_eq!(attachment.format_inner().to_string(), "42");
+    /// ```
+    #[must_use]
+    pub fn into_inner_as_any_mut(self) -> &'a mut (dyn Any + 'static) {
+        let raw = self.into_raw_mut();
+        raw.into_attachment_as_any_mut()
     }
 
     /// Formats the inner attachment data with formatting hooks applied.

--- a/src/report_attachment/owned.rs
+++ b/src/report_attachment/owned.rs
@@ -1,4 +1,4 @@
-use core::any::TypeId;
+use core::any::{Any, TypeId};
 
 use rootcause_internals::{
     RawAttachment,
@@ -369,6 +369,48 @@ impl<A: ?Sized, T> ReportAttachment<A, T> {
     #[must_use]
     pub fn inner_handler_type_id(&self) -> TypeId {
         self.as_raw_ref().attachment_handler_type_id()
+    }
+
+    /// Returns a [`&dyn Any`](Any) view of the inner attachment.
+    ///
+    /// This works whether the attachment type `A` is known at compile time or
+    /// erased to [`Dynamic`]. The returned reference can be downcast using
+    /// `<dyn Any>::downcast_ref`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use rootcause::{prelude::*, report_attachment::ReportAttachment};
+    /// # use core::any::Any;
+    /// let attachment = ReportAttachment::new_sendsync(42i32);
+    /// let any: &dyn Any = attachment.inner_as_any();
+    /// assert_eq!(any.downcast_ref::<i32>(), Some(&42));
+    /// ```
+    #[must_use]
+    pub fn inner_as_any(&self) -> &(dyn Any + 'static) {
+        self.as_ref().inner_as_any()
+    }
+
+    /// Returns a [`&mut dyn Any`](Any) view of the inner attachment.
+    ///
+    /// The returned reference can be downcast using
+    /// `<dyn Any>::downcast_mut`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use rootcause::{prelude::*, report_attachment::ReportAttachment};
+    /// # use core::any::Any;
+    /// let mut attachment = ReportAttachment::new_sendsync(41i32);
+    /// let any: &mut dyn Any = attachment.inner_as_any_mut();
+    /// if let Some(n) = any.downcast_mut::<i32>() {
+    ///     *n += 1;
+    /// }
+    /// assert_eq!(attachment.format_inner().to_string(), "42");
+    /// ```
+    #[must_use]
+    pub fn inner_as_any_mut(&mut self) -> &mut (dyn Any + 'static) {
+        self.as_mut().into_inner_as_any_mut()
     }
 
     /// Formats the attachment with hook processing.

--- a/src/report_attachment/ref_.rs
+++ b/src/report_attachment/ref_.rs
@@ -1,4 +1,4 @@
-use core::any::TypeId;
+use core::any::{Any, TypeId};
 
 use rootcause_internals::handlers::{AttachmentFormattingStyle, FormattingFunction};
 
@@ -204,6 +204,35 @@ impl<'a, A: ?Sized> ReportAttachmentRef<'a, A> {
     #[must_use]
     pub fn inner_handler_type_id(self) -> TypeId {
         self.as_raw_ref().attachment_handler_type_id()
+    }
+
+    /// Returns a [`&dyn Any`](Any) view of the inner attachment.
+    ///
+    /// This is the most general accessor for the inner attachment: it works
+    /// whether the attachment type `A` is known at compile time or erased to
+    /// [`Dynamic`]. The returned reference can be downcast using
+    /// `<dyn Any>::downcast_ref` and interoperates with
+    /// any code that accepts `&dyn Any`.
+    ///
+    /// # Examples
+    /// ```
+    /// use core::any::Any;
+    ///
+    /// use rootcause::{
+    ///     markers::Dynamic,
+    ///     prelude::*,
+    ///     report_attachment::{ReportAttachment, ReportAttachmentRef},
+    /// };
+    ///
+    /// let attachment: ReportAttachment<&str> = ReportAttachment::new("text data");
+    /// let attachment: ReportAttachment<Dynamic> = attachment.into_dynamic();
+    /// let attachment_ref: ReportAttachmentRef<'_, Dynamic> = attachment.as_ref();
+    /// let any: &dyn Any = attachment_ref.inner_as_any();
+    /// assert_eq!(any.downcast_ref::<&str>(), Some(&"text data"));
+    /// ```
+    #[must_use]
+    pub fn inner_as_any(self) -> &'a (dyn Any + 'static) {
+        self.as_raw_ref().attachment_as_any()
     }
 
     /// Formats the inner attachment data with formatting hooks applied.


### PR DESCRIPTION
Fixes #151.

Adds `current_context_as_any` / `inner_as_any` (+ `_mut` variants) on `Report*` and `ReportAttachment*`. Available on `?Sized + 'static`, so works for both typed and `Dynamic`. Dispatch via two new vtable fn pointers per vtable. `downcast_current_context` kept as-is.