### PR TITLE
Polish follow-up to #148 (rootcause-preformat)

### DIFF
--- a/examples/context_methods.rs
+++ b/examples/context_methods.rs
@@ -61,9 +61,9 @@ fn main() {
     println!("{report2}\n");
     assert_eq!(report2.iter_sub_reports().count(), 0);
 
-    // Clones the context to preserve multiple locations, while preserving the original
-    // context type
-    println!("Using context_transform_nested():");
+    // Clones the context to preserve multiple locations, while preserving the
+    // original context type
+    println!("Using cloned context + context():");
     let report3 = parse_error("not_a_number");
     let report3_context = report3.current_context().clone();
     let report3 = report3.context(AppError::Parse(report3_context));
@@ -74,7 +74,7 @@ fn main() {
         std::any::TypeId::of::<std::num::ParseIntError>()
     );
 
-    // context_to() - Uses ReportConversion impl (context_transform_nested in this
+    // context_to() - Uses ReportConversion impl (clone + context() in this
     // example)
     println!("Using context_to():");
     let report4: Report<AppError> = parse_error("not_a_number").context_to::<AppError>();

--- a/rootcause-preformat/README.md
+++ b/rootcause-preformat/README.md
@@ -84,7 +84,7 @@ This crate's MSRV matches rootcause: **1.89.0**
 ## License
 
 <sup>
-Licensed under either of <a href="../LICENSE-APACHE">Apache License, Version 2.0</a> or <a href="../LICENSE-MIT">MIT license</a> at your option.
+Licensed under either of <a href="LICENSE-APACHE">Apache License, Version 2.0</a> or <a href="LICENSE-MIT">MIT license</a> at your option.
 </sup>
 
 <br>

--- a/rootcause-preformat/src/lib.rs
+++ b/rootcause-preformat/src/lib.rs
@@ -506,10 +506,7 @@ mod tests {
         for preformatted in [&from_owned, &from_ref, &from_mut] {
             assert_eq!(format!("{}", preformatted.format_inner()), display);
             assert_eq!(format!("{:?}", preformatted.format_inner()), debug);
-            assert_eq!(
-                preformatted.inner().original_type_id(),
-                TypeId::of::<u32>(),
-            );
+            assert_eq!(preformatted.inner().original_type_id(), TypeId::of::<u32>(),);
         }
     }
 }

--- a/rootcause-preformat/src/lib.rs
+++ b/rootcause-preformat/src/lib.rs
@@ -388,13 +388,35 @@ impl<V, C, T> ContextTransformNestedExt<C, T> for Result<V, Report<C, Mutable, T
 
 #[cfg(test)]
 mod tests {
+    use alloc::format;
+    use core::any::TypeId;
+
     use rootcause::{
         ReportRef,
         markers::{Local, Mutable, SendSync, Uncloneable},
         prelude::*,
+        report_attachment::ReportAttachment,
     };
 
     use super::*;
+
+    #[derive(Debug)]
+    struct DemoError(u32);
+
+    impl core::fmt::Display for DemoError {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            write!(f, "demo {}", self.0)
+        }
+    }
+
+    #[derive(Debug)]
+    struct Wrapper(#[allow(dead_code)] DemoError);
+
+    impl core::fmt::Display for Wrapper {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            write!(f, "wrapper")
+        }
+    }
 
     #[test]
     fn test_preformat() {
@@ -404,6 +426,90 @@ mod tests {
         let report = report!(non_send_sync_error);
         let report_ref: ReportRef<'_, NonSendSyncError, Uncloneable, Local> = report.as_ref();
         let preformatted: Report<PreformattedContext, Mutable, SendSync> = report_ref.preformat();
-        assert_eq!(alloc::format!("{report}"), alloc::format!("{preformatted}"));
+        assert_eq!(format!("{report}"), format!("{preformatted}"));
+    }
+
+    #[test]
+    fn test_preformat_root_extracts_typed_context() {
+        let report: Report<DemoError> = report!(DemoError(7)).attach("ctx-detail");
+        let display_before = format!("{report}");
+        let attachments_before = report.attachments().len();
+
+        let (context, preformatted) = report.preformat_root();
+
+        assert_eq!(context.0, 7);
+        assert_eq!(format!("{preformatted}"), display_before);
+        assert_eq!(
+            preformatted.current_context().original_type_id(),
+            TypeId::of::<DemoError>(),
+        );
+        assert_eq!(preformatted.attachments().len(), attachments_before);
+    }
+
+    #[test]
+    fn test_context_transform_nested_on_report() {
+        let inner: Report<DemoError> = report!(DemoError(3));
+
+        let outer: Report<Wrapper> = inner.context_transform_nested(Wrapper);
+
+        assert_eq!(outer.current_context_type_id(), TypeId::of::<Wrapper>());
+        assert_eq!(outer.iter_sub_reports().count(), 1);
+        let child = outer.children().get(0).unwrap();
+        assert_eq!(
+            child.current_context_type_id(),
+            TypeId::of::<PreformattedContext>(),
+        );
+        let child_typed = child
+            .downcast_report::<PreformattedContext>()
+            .expect("child should be PreformattedContext");
+        assert_eq!(
+            child_typed.current_context().original_type_id(),
+            TypeId::of::<DemoError>(),
+        );
+    }
+
+    #[test]
+    fn test_context_transform_nested_on_result_ok_passes_through() {
+        let ok: Result<i32, Report<DemoError>> = Ok(42);
+        let mapped: Result<i32, Report<Wrapper>> = ok.context_transform_nested(Wrapper);
+        assert_eq!(mapped.unwrap(), 42);
+    }
+
+    #[test]
+    fn test_context_transform_nested_on_result_err_wraps() {
+        let err: Result<i32, Report<DemoError>> = Err(report!(DemoError(9)));
+        let mapped: Result<i32, Report<Wrapper>> = err.context_transform_nested(Wrapper);
+
+        let outer = mapped.unwrap_err();
+        assert_eq!(outer.current_context_type_id(), TypeId::of::<Wrapper>());
+        assert_eq!(outer.iter_sub_reports().count(), 1);
+        let child = outer.children().get(0).unwrap();
+        let child_typed = child
+            .downcast_report::<PreformattedContext>()
+            .expect("child should be PreformattedContext");
+        assert_eq!(
+            child_typed.current_context().original_type_id(),
+            TypeId::of::<DemoError>(),
+        );
+    }
+
+    #[test]
+    fn test_preformat_attachment_owned_ref_mut() {
+        let mut attachment = ReportAttachment::new_sendsync(42u32);
+        let display = format!("{}", attachment.format_inner());
+        let debug = format!("{:?}", attachment.format_inner());
+
+        let from_owned = attachment.preformat();
+        let from_ref = attachment.as_ref().preformat();
+        let from_mut = attachment.as_mut().preformat();
+
+        for preformatted in [&from_owned, &from_ref, &from_mut] {
+            assert_eq!(format!("{}", preformatted.format_inner()), display);
+            assert_eq!(format!("{:?}", preformatted.format_inner()), debug);
+            assert_eq!(
+                preformatted.inner().original_type_id(),
+                TypeId::of::<u32>(),
+            );
+        }
     }
 }


### PR DESCRIPTION
Follow-up polish for #148:

- `examples/context_methods.rs`: the `println!` label still said
  `"Using context_transform_nested():"` even though the code now uses
  clone + `context()`. Updated the label and the related `context_to()`
  comment.
- `rootcause-preformat/README.md`: license links pointed at
  `../LICENSE-APACHE` / `../LICENSE-MIT`. Switched to in-crate paths so
  they resolve on crates.io / docs.rs.
- `rootcause-preformat`: added unit tests for `PreformatRootExt`,
  `ContextTransformNestedExt` (both `Report` and `Result` impls), and
  `PreformatAttachmentExt` (owned / ref / mut).

No external API change; no CHANGELOG entry.