### PR TITLE
Tighten CHANGELOG entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `current_context_as_any` / `current_context_as_any_mut` on `Report`/`ReportRef`/`ReportMut` and `inner_as_any` / `inner_as_any_mut` on `ReportAttachment`/`ReportAttachmentRef`/`ReportAttachmentMut` for `&dyn Any` access to contexts and attachments [#151](https://github.com/rootcause-rs/rootcause/issues/151).
+- `&dyn Any` accessors for contexts and attachments via `current_context_as_any(_mut)` on `Report`/`ReportRef`/`ReportMut` and `inner_as_any(_mut)` on `ReportAttachment`/`ReportAttachmentRef`/`ReportAttachmentMut` [#151](https://github.com/rootcause-rs/rootcause/issues/151).
 - Added a compatibility module for error-stack v0.7 [#169](https://github.com/rootcause-rs/rootcause/pull/169).
-- Implement `Deref<Target = dyn Error>` and `AsRef<dyn Error>` for `Report`, `ReportRef` and `ReportMut`. `Report<_, _, SendSync>` targets `dyn Error + Send + Sync`. Splitting `Deref` by thread-safety marker may break type inference at call sites of `Report::new_custom` / `Report::new`; use `new_sendsync_custom` / `new_local_custom` or explicit annotations to fix. [#147](https://github.com/rootcause-rs/rootcause/pull/147), [#149](https://github.com/rootcause-rs/rootcause/pull/149)
+- Implement `Deref<Target = dyn Error>` and `AsRef<dyn Error>` for `Report`, `ReportRef` and `ReportMut`; `Report<_, _, SendSync>` targets `dyn Error + Send + Sync`. May break type inference at some `Report::new*` call sites. [#147](https://github.com/rootcause-rs/rootcause/pull/147), [#149](https://github.com/rootcause-rs/rootcause/pull/149)
 - Doc examples for nearly all public functions [#136](https://github.com/rootcause-rs/rootcause/pull/136).
 
 ### Changed
 
-- Moved the preformat functionality out of `rootcause` and into a new companion crate, `rootcause-preformat`. The `preformatted` module, the `preformat`, `preformat_root`, and `context_transform_nested` methods on `Report`/`ReportRef`/`ReportMut`/`ReportAttachment*`/`ResultExt`, and the `display_preformatted`/`debug_preformatted` methods on the formatter-hook traits are removed; `AttachmentFormatterHook::preferred_formatting_style` and `ContextFormatterHook::preferred_context_formatting_style` now take the concrete type rather than `Dynamic`. The functionality is available through the `PreformatReportExt`, `PreformatAttachmentExt`, `PreformatRootExt`, and `ContextTransformNestedExt` extension traits in the new crate. [#148](https://github.com/rootcause-rs/rootcause/pull/148)
+- Moved the preformat functionality out of `rootcause` into the new `rootcause-preformat` companion crate. The `preformatted` module, the `preformat*` methods, and the `display_preformatted`/`debug_preformatted` formatter-hook methods are removed; use the `Preformat*Ext` and `ContextTransformNestedExt` traits from the new crate. `AttachmentFormatterHook::preferred_formatting_style` and `ContextFormatterHook::preferred_context_formatting_style` now take a concrete type instead of `Dynamic`. [#148](https://github.com/rootcause-rs/rootcause/pull/148)
 
 ### Fixed
 
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed some issues with using rootcause-backtrace on windows [#118](https://github.com/rootcause-rs/rootcause/pull/94), [#120](https://github.com/rootcause-rs/rootcause/pull/120), [#121](https://github.com/rootcause-rs/rootcause/pull/121).
+- Fixed some issues with using rootcause-backtrace on windows [#118](https://github.com/rootcause-rs/rootcause/pull/118), [#120](https://github.com/rootcause-rs/rootcause/pull/120), [#121](https://github.com/rootcause-rs/rootcause/pull/121).
 
 ## [0.11.1] - 2026-01-03
 
@@ -93,7 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added a new `compat` module added poulated it with `eyre` and `error-stack` compatibility [#55](https://github.com/rootcause-rs/rootcause/pull/55)
+- Added a new `compat` module and populated it with `eyre` and `error-stack` compatibility [#55](https://github.com/rootcause-rs/rootcause/pull/55)
 - Added a `format_with_hook` method on reports to format a report using a specific hook [#57](https://github.com/rootcause-rs/rootcause/pull/57)
 
 ### Changed
@@ -126,8 +126,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- More docs, examples, README [#40](https://github.com/rootcause-rs/rootcause/pull/40)
-- More docs, examples, README [#41](https://github.com/rootcause-rs/rootcause/pull/41)
+- More docs, examples, README [#40](https://github.com/rootcause-rs/rootcause/pull/40), [#41](https://github.com/rootcause-rs/rootcause/pull/41)
 
 ## [0.6.0] - 2025-10-29
 


### PR DESCRIPTION
- Trim the bloated `[Unreleased]` entries (drop per-method enumerations, fold the `Deref` migration prose into a one-line breakage hint).
- Fix the broken `#118` link in 0.12.0 that pointed at `pull/94`.
- Fix "added poulated it" typo in 0.9.0.
- Merge the duplicate "More docs, examples, README" lines in 0.7.0.