### PR TITLE
Add intradoc links across public docs per style guide

### DIFF
--- a/rootcause-internals/src/handlers.rs
+++ b/rootcause-internals/src/handlers.rs
@@ -21,9 +21,9 @@
 /// Implement this trait when you need custom formatting behavior that the
 /// built-in handlers don't provide, such as:
 /// - Custom source chain navigation for types that don't implement
-///   `std::error::Error`
-/// - Special display formatting that differs from the type's `Display`
-///   implementation
+///   [`core::error::Error`]
+/// - Special display formatting that differs from the type's
+///   [`Display`](core::fmt::Display) implementation
 /// - Dynamic formatting based on the context value
 ///
 /// # Required Methods
@@ -90,8 +90,8 @@ pub trait ContextHandler<C>: 'static {
     ///
     /// # Examples
     ///
-    /// For types implementing `std::error::Error`, delegate to their `source`
-    /// method:
+    /// For types implementing [`core::error::Error`], delegate to their
+    /// [`source`](core::error::Error::source) method:
     ///
     /// ```
     /// use std::error::Error;
@@ -514,8 +514,9 @@ pub struct AttachmentFormattingStyle {
 ///
 /// # Variants
 ///
-/// - **`Display`** (default): Use the `display` method
-/// - **`Debug`**: Use the `debug` method
+/// - **[`Display`](FormattingFunction::Display)** (default): Use the
+///   `display` method
+/// - **[`Debug`](FormattingFunction::Debug)**: Use the `debug` method
 ///
 /// # Examples
 ///

--- a/rootcause-preformat/src/preformatted.rs
+++ b/rootcause-preformat/src/preformatted.rs
@@ -49,7 +49,7 @@ use rootcause::{
 };
 
 /// A context that has been preformatted into `String`s for both
-/// `Display` and `Debug`.
+/// [`Display`](core::fmt::Display) and [`Debug`](core::fmt::Debug).
 ///
 /// This type stores the formatted output of a context along with metadata about
 /// the original type and preferred formatting styles. It's created
@@ -59,9 +59,10 @@ use rootcause::{
 /// # Stored Information
 ///
 /// - The original type's [`TypeId`] (accessible via [`original_type_id`])
-/// - Preformatted `Display` output as a `String`
-/// - Preformatted `Debug` output as a `String`
-/// - Preferred formatting styles for both `Display` and `Debug`
+/// - Preformatted [`Display`](core::fmt::Display) output as a `String`
+/// - Preformatted [`Debug`](core::fmt::Debug) output as a `String`
+/// - Preferred formatting styles for both [`Display`](core::fmt::Display)
+///   and [`Debug`](core::fmt::Debug)
 ///
 /// # Examples
 ///
@@ -159,7 +160,7 @@ impl PreformattedContext {
 }
 
 /// An attachment that has been preformatted into `String`s for both
-/// `Display` and `Debug`.
+/// [`Display`](core::fmt::Display) and [`Debug`](core::fmt::Debug).
 ///
 /// This type stores the formatted output of an attachment along with metadata
 /// about the original type and preferred formatting styles. It's created
@@ -169,9 +170,10 @@ impl PreformattedContext {
 /// # Stored Information
 ///
 /// - The original type's [`TypeId`] (accessible via [`original_type_id`])
-/// - Preformatted `Display` output as a `String`
-/// - Preformatted `Debug` output as a `String`
-/// - Preferred formatting styles for both `Display` and `Debug`
+/// - Preformatted [`Display`](core::fmt::Display) output as a `String`
+/// - Preformatted [`Debug`](core::fmt::Debug) output as a `String`
+/// - Preferred formatting styles for both [`Display`](core::fmt::Display)
+///   and [`Debug`](core::fmt::Debug)
 ///
 /// # Examples
 ///

--- a/rootcause-tracing/examples/tracing_spans.rs
+++ b/rootcause-tracing/examples/tracing_spans.rs
@@ -4,7 +4,7 @@
 //! they include the active span context showing which operations were running.
 //!
 //! If you currently use `tracing_subscriber::fmt::init()`, this shows how to
-//! expand that setup to add `RootcauseLayer`.
+//! expand that setup to add [`RootcauseLayer`](rootcause_tracing::RootcauseLayer).
 
 use rootcause::{hooks::Hooks, prelude::*};
 use rootcause_tracing::{RootcauseLayer, SpanCollector};

--- a/rootcause-tracing/src/lib.rs
+++ b/rootcause-tracing/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! You add [`RootcauseLayer`] to your tracing subscriber alongside your
 //! existing layers (formatting, filtering, log forwarding, etc.). While your
-//! other layers do their work, `RootcauseLayer` quietly captures span field
+//! other layers do their work, [`RootcauseLayer`] quietly captures span field
 //! values in the background for use in error reports.
 //!
 //! # Quick Start

--- a/src/compat/anyhow1.rs
+++ b/src/compat/anyhow1.rs
@@ -122,9 +122,10 @@
 //! The [`AnyhowHandler`] delegates to anyhow's own formatting implementation,
 //! ensuring that converted errors display exactly as they would in pure anyhow
 //! code. This includes:
-//! - Display formatting via [`anyhow::Error`]'s `Display` implementation
-//! - Debug formatting via [`anyhow::Error`]'s `Debug` implementation
-//! - Source chain navigation via [`anyhow::Error`]'s `source` method
+//! - Display formatting via [`anyhow::Error`]'s [`Display`](core::fmt::Display) implementation
+//! - Debug formatting via [`anyhow::Error`]'s [`Debug`](core::fmt::Debug) implementation
+//! - Source chain navigation via [`anyhow::Error`]'s
+//!   [`source`](core::error::Error::source) method
 //!
 //! When converting from rootcause to anyhow, the entire [`Report`] structure
 //! (including all contexts and attachments) is preserved and formatted
@@ -145,10 +146,10 @@ use crate::{Report, compat::ReportAsError, markers};
 ///
 /// # Implementation Details
 ///
-/// - **Display**: Uses [`anyhow::Error`]'s `Display` implementation
-/// - **Debug**: Uses [`anyhow::Error`]'s `Debug` implementation
-/// - **Source**: Uses [`anyhow::Error`]'s `source` method to traverse the error
-///   chain
+/// - **Display**: Uses [`anyhow::Error`]'s [`Display`](core::fmt::Display) implementation
+/// - **Debug**: Uses [`anyhow::Error`]'s [`Debug`](core::fmt::Debug) implementation
+/// - **Source**: Uses [`anyhow::Error`]'s [`source`](core::error::Error::source)
+///   method to traverse the error chain
 /// - **Formatting style**: Matches the report's formatting function (Display or
 ///   Debug)
 ///

--- a/src/compat/boxed_error.rs
+++ b/src/compat/boxed_error.rs
@@ -134,10 +134,10 @@ use crate::{
 ///
 /// # Implementation Details
 ///
-/// - **Display**: Uses the boxed error's `Display` implementation
-/// - **Debug**: Uses the boxed error's `Debug` implementation
-/// - **Source**: Uses the boxed error's `source` method to traverse the error
-///   chain
+/// - **Display**: Uses the boxed error's [`Display`](core::fmt::Display) implementation
+/// - **Debug**: Uses the boxed error's [`Debug`](core::fmt::Debug) implementation
+/// - **Source**: Uses the boxed error's [`source`](core::error::Error::source)
+///   method to traverse the error chain
 /// - **Formatting style**: Matches the report's formatting function (Display or
 ///   Debug)
 ///

--- a/src/compat/error_stack05.rs
+++ b/src/compat/error_stack05.rs
@@ -125,9 +125,10 @@
 //! The [`ErrorStackHandler`] delegates to error-stack's own formatting
 //! implementation, ensuring that converted reports display exactly as they
 //! would in pure error-stack code. This includes:
-//! - Display formatting via [`error_stack::Report`]'s `Display` implementation
-//! - Debug formatting via [`error_stack::Report`]'s `Debug` implementation
-//! - Source chain navigation via the context's `source` method
+//! - Display formatting via [`error_stack::Report`]'s [`Display`](core::fmt::Display) implementation
+//! - Debug formatting via [`error_stack::Report`]'s [`Debug`](core::fmt::Debug) implementation
+//! - Source chain navigation via the context's
+//!   [`source`](core::error::Error::source) method
 //!
 //! When converting from rootcause to error-stack, the entire [`Report`]
 //! structure (including all contexts and attachments) is preserved and
@@ -156,10 +157,10 @@ use crate::{
 ///
 /// # Implementation Details
 ///
-/// - **Display**: Uses [`error_stack::Report`]'s `Display` implementation
-/// - **Debug**: Uses [`error_stack::Report`]'s `Debug` implementation
-/// - **Source**: Uses the current context's `source` method to traverse the
-///   error chain
+/// - **Display**: Uses [`error_stack::Report`]'s [`Display`](core::fmt::Display) implementation
+/// - **Debug**: Uses [`error_stack::Report`]'s [`Debug`](core::fmt::Debug) implementation
+/// - **Source**: Uses the current context's
+///   [`source`](core::error::Error::source) method to traverse the error chain
 /// - **Formatting style**: Matches the report's formatting function (Display or
 ///   Debug)
 ///

--- a/src/compat/error_stack06.rs
+++ b/src/compat/error_stack06.rs
@@ -125,9 +125,10 @@
 //! The [`ErrorStackHandler`] delegates to error-stack's own formatting
 //! implementation, ensuring that converted reports display exactly as they
 //! would in pure error-stack code. This includes:
-//! - Display formatting via [`error_stack::Report`]'s `Display` implementation
-//! - Debug formatting via [`error_stack::Report`]'s `Debug` implementation
-//! - Source chain navigation via the context's `source` method
+//! - Display formatting via [`error_stack::Report`]'s [`Display`](core::fmt::Display) implementation
+//! - Debug formatting via [`error_stack::Report`]'s [`Debug`](core::fmt::Debug) implementation
+//! - Source chain navigation via the context's
+//!   [`source`](core::error::Error::source) method
 //!
 //! When converting from rootcause to error-stack, the entire [`Report`]
 //! structure (including all contexts and attachments) is preserved and
@@ -156,10 +157,10 @@ use crate::{
 ///
 /// # Implementation Details
 ///
-/// - **Display**: Uses [`error_stack::Report`]'s `Display` implementation
-/// - **Debug**: Uses [`error_stack::Report`]'s `Debug` implementation
-/// - **Source**: Uses the current context's `source` method to traverse the
-///   error chain
+/// - **Display**: Uses [`error_stack::Report`]'s [`Display`](core::fmt::Display) implementation
+/// - **Debug**: Uses [`error_stack::Report`]'s [`Debug`](core::fmt::Debug) implementation
+/// - **Source**: Uses the current context's
+///   [`source`](core::error::Error::source) method to traverse the error chain
 /// - **Formatting style**: Matches the report's formatting function (Display or
 ///   Debug)
 ///

--- a/src/compat/error_stack07.rs
+++ b/src/compat/error_stack07.rs
@@ -125,9 +125,10 @@
 //! The [`ErrorStackHandler`] delegates to error-stack's own formatting
 //! implementation, ensuring that converted reports display exactly as they
 //! would in pure error-stack code. This includes:
-//! - Display formatting via [`error_stack::Report`]'s `Display` implementation
-//! - Debug formatting via [`error_stack::Report`]'s `Debug` implementation
-//! - Source chain navigation via the context's `source` method
+//! - Display formatting via [`error_stack::Report`]'s [`Display`](core::fmt::Display) implementation
+//! - Debug formatting via [`error_stack::Report`]'s [`Debug`](core::fmt::Debug) implementation
+//! - Source chain navigation via the context's
+//!   [`source`](core::error::Error::source) method
 //!
 //! When converting from rootcause to error-stack, the entire [`Report`]
 //! structure (including all contexts and attachments) is preserved and
@@ -156,10 +157,10 @@ use crate::{
 ///
 /// # Implementation Details
 ///
-/// - **Display**: Uses [`error_stack::Report`]'s `Display` implementation
-/// - **Debug**: Uses [`error_stack::Report`]'s `Debug` implementation
-/// - **Source**: Uses the current context's `source` method to traverse the
-///   error chain
+/// - **Display**: Uses [`error_stack::Report`]'s [`Display`](core::fmt::Display) implementation
+/// - **Debug**: Uses [`error_stack::Report`]'s [`Debug`](core::fmt::Debug) implementation
+/// - **Source**: Uses the current context's
+///   [`source`](core::error::Error::source) method to traverse the error chain
 /// - **Formatting style**: Matches the report's formatting function (Display or
 ///   Debug)
 ///

--- a/src/compat/eyre06.rs
+++ b/src/compat/eyre06.rs
@@ -122,9 +122,10 @@
 //! The [`EyreHandler`] delegates to eyre's own formatting implementation,
 //! ensuring that converted reports display exactly as they would in pure eyre
 //! code. This includes:
-//! - Display formatting via [`eyre::Report`]'s `Display` implementation
-//! - Debug formatting via [`eyre::Report`]'s `Debug` implementation
-//! - Source chain navigation via [`eyre::Report`]'s `source` method
+//! - Display formatting via [`eyre::Report`]'s [`Display`](core::fmt::Display) implementation
+//! - Debug formatting via [`eyre::Report`]'s [`Debug`](core::fmt::Debug) implementation
+//! - Source chain navigation via [`eyre::Report`]'s
+//!   [`source`](core::error::Error::source) method
 //!
 //! When converting from rootcause to eyre, the entire [`Report`] structure
 //! (including all contexts and attachments) is preserved and formatted
@@ -145,10 +146,10 @@ use crate::{Report, compat::ReportAsError, markers};
 ///
 /// # Implementation Details
 ///
-/// - **Display**: Uses [`eyre::Report`]'s `Display` implementation
-/// - **Debug**: Uses [`eyre::Report`]'s `Debug` implementation
-/// - **Source**: Uses [`eyre::Report`]'s `source` method to traverse the error
-///   chain
+/// - **Display**: Uses [`eyre::Report`]'s [`Display`](core::fmt::Display) implementation
+/// - **Debug**: Uses [`eyre::Report`]'s [`Debug`](core::fmt::Debug) implementation
+/// - **Source**: Uses [`eyre::Report`]'s [`source`](core::error::Error::source)
+///   method to traverse the error chain
 /// - **Formatting style**: Matches the report's formatting function (Display or
 ///   Debug)
 ///

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -50,7 +50,9 @@
 //! ## [`Error`]
 //!
 //! For types implementing [`std::error::Error`](core::error::Error). Delegates
-//! to the type's `Display`, `Debug`, and `source` implementations. This is the
+//! to the type's [`Display`](core::fmt::Display),
+//! [`Debug`](core::fmt::Debug), and
+//! [`source`](core::error::Error::source) implementations. This is the
 //! default handler for error types.
 //!
 //! ## [`Display`]
@@ -103,13 +105,14 @@ pub use rootcause_internals::handlers::{
 /// This handler delegates to the error type's existing implementations of
 /// [`Error::source`](core::error::Error::source),
 /// [`Display`](core::fmt::Display), and [`Debug`](core::fmt::Debug). This is
-/// the default handler for any type that implements the `Error` trait.
+/// the default handler for any type that implements the
+/// [`Error`](core::error::Error) trait.
 ///
 /// # When to Use
 ///
 /// This handler is automatically selected by the [`report!`](crate::report!)
-/// macro when you create a report from a type implementing `std::error::Error`.
-/// You rarely need to specify it explicitly.
+/// macro when you create a report from a type implementing
+/// [`std::error::Error`]. You rarely need to specify it explicitly.
 ///
 /// # Examples
 ///
@@ -147,17 +150,18 @@ where
 /// Handler for types implementing [`Display`](core::fmt::Display) and
 /// [`Debug`](core::fmt::Debug).
 ///
-/// This handler delegates to the type's `Display` and `Debug` implementations
-/// for formatting. This is suitable for custom context types that aren't errors
-/// but can be meaningfully displayed. The [`source`](ContextHandler::source)
-/// method always returns `None` since these types don't have error sources.
+/// This handler delegates to the type's [`Display`](core::fmt::Display) and
+/// [`Debug`](core::fmt::Debug) implementations for formatting. This is suitable
+/// for custom context types that aren't errors but can be meaningfully
+/// displayed. The [`source`](ContextHandler::source) method always returns
+/// `None` since these types don't have error sources.
 ///
 /// # When to Use
 ///
-/// This handler is automatically selected for types that implement `Display`
-/// and `Debug` but not `std::error::Error`. This is ideal for custom context
-/// types like configuration objects, request parameters, or descriptive
-/// messages.
+/// This handler is automatically selected for types that implement
+/// [`Display`](core::fmt::Display) and [`Debug`](core::fmt::Debug) but not
+/// [`std::error::Error`]. This is ideal for custom context types like
+/// configuration objects, request parameters, or descriptive messages.
 ///
 /// ⚠️ When returning a `Result` value from `main`, the error will always be formatted
 /// with [`Debug`](core::fmt::Debug)-formatting, which results in `Debug`-formatting
@@ -239,17 +243,17 @@ where
 
 /// Handler for types implementing [`Debug`](core::fmt::Debug).
 ///
-/// This handler uses the type's `Debug` implementation for the `debug` method,
-/// but shows a generic message like "Context of type `TypeName`" for the
-/// `display` method. This is useful for types that have debug information but
-/// don't implement `Display`.
+/// This handler uses the type's [`Debug`](core::fmt::Debug) implementation for
+/// the `debug` method, but shows a generic message like "Context of type
+/// `TypeName`" for the `display` method. This is useful for types that have
+/// debug information but don't implement [`Display`](core::fmt::Display).
 ///
 /// # When to Use
 ///
-/// This handler is automatically selected for types that implement `Debug` but
-/// not `Display`. This is useful for internal data structures or types where
-/// displaying the full debug output as the primary message would be too
-/// verbose.
+/// This handler is automatically selected for types that implement
+/// [`Debug`](core::fmt::Debug) but not [`Display`](core::fmt::Display). This is
+/// useful for internal data structures or types where displaying the full
+/// debug output as the primary message would be too verbose.
 ///
 /// # Formatting Behavior
 ///
@@ -322,9 +326,10 @@ where
 /// Handler for any type, regardless of implemented traits.
 ///
 /// This is the most generic handler, working with any type without requiring
-/// `Display`, `Debug`, or `Error` implementations. Both `Display` and `Debug`
-/// output show "An object of type TypeName" using
-/// [`type_name`](core::any::type_name).
+/// [`Display`](core::fmt::Display), [`Debug`](core::fmt::Debug), or
+/// [`Error`](core::error::Error) implementations. Both
+/// [`Display`](core::fmt::Display) and [`Debug`](core::fmt::Debug) output show
+/// "An object of type TypeName" using [`type_name`](core::any::type_name).
 ///
 /// # When to Use
 ///

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -258,7 +258,7 @@ where
 /// # Formatting Behavior
 ///
 /// - **`display` method**: Shows "Context of type `TypeName`"
-/// - **`debug` method**: Uses the type's `Debug` implementation
+/// - **`debug` method**: Uses the type's [`Debug`](core::fmt::Debug) implementation
 /// - **`source` method**: Always returns `None`
 /// - **Preferred formatting**: Same as requested formatting of the report.
 ///

--- a/src/hooks/attachment_formatter.rs
+++ b/src/hooks/attachment_formatter.rs
@@ -118,8 +118,9 @@
 //!
 //! ## Suppressing display of Attachments
 //!
-//! Omit noisy or unnecessary information by setting placement to `Opaque`
-//! when formatting as display:
+//! Omit noisy or unnecessary information by setting placement to
+//! [`Opaque`](crate::handlers::AttachmentFormattingPlacement::Opaque) when
+//! formatting as display:
 //!
 //! ```
 //! use rootcause::{

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -31,8 +31,9 @@
 //!   structure)
 //! - Redact or transform sensitive data in error messages
 //!
-//! **If you just need to customize a single error**, use `.attach()` or
-//! handlers (see [`examples/custom_handler.rs`]) instead of hooks.
+//! **If you just need to customize a single error**, use
+//! [`.attach()`](crate::Report::attach) or handlers (see
+//! [`examples/custom_handler.rs`]) instead of hooks.
 //!
 //! [`examples/custom_handler.rs`]: https://github.com/rootcause-rs/rootcause/blob/main/examples/custom_handler.rs
 //!
@@ -233,7 +234,7 @@ impl core::fmt::Display for HooksAlreadyInstalledError {
 impl core::error::Error for HooksAlreadyInstalledError {}
 
 impl Hooks {
-    /// Creates a new `Hooks` builder with location tracking.
+    /// Creates a new [`Hooks`] builder with location tracking.
     ///
     /// This is equivalent to using rootcause without installing any hooks - you
     /// get automatic location tracking. Use this as the base when you want to
@@ -264,7 +265,7 @@ impl Hooks {
         }))
     }
 
-    /// Creates a new `Hooks` builder without location tracking.
+    /// Creates a new [`Hooks`] builder without location tracking.
     ///
     /// By default, rootcause automatically tracks source locations where errors
     /// occur. Use this method when you don't want that automatic tracking.
@@ -580,7 +581,7 @@ impl Hooks {
 
 /// A handle to hooks that have been leaked into static memory.
 ///
-/// You get a `HooksHandle` when calling [`Hooks::replace()`], which returns
+/// You get a [`HooksHandle`] when calling [`Hooks::replace()`], which returns
 /// the previously installed hooks. The hooks remain in memory for the lifetime
 /// of the program unless you call the unsafe [`reclaim()`](Self::reclaim)
 /// method.
@@ -595,7 +596,7 @@ impl Hooks {
 ///
 /// # Memory Leak Warning
 ///
-/// Dropping a `HooksHandle` **will leak memory**. This is by design - the hooks
+/// Dropping a [`HooksHandle`] **will leak memory**. This is by design - the hooks
 /// might still be referenced by other threads, so we can't safely deallocate
 /// them. In most applications this is fine since you typically install hooks
 /// once at startup. If you're replacing hooks frequently in tests or hot-reload
@@ -709,7 +710,7 @@ impl HooksHandle {
         Some(Self { hook_data })
     }
 
-    /// Reclaims ownership of the leaked hooks, returning them as a `Hooks`
+    /// Reclaims ownership of the leaked hooks, returning them as a [`Hooks`]
     /// instance.
     ///
     /// **⚠ WARNING: This function is almost impossible to use safely. Do not

--- a/src/hooks/report_creation.rs
+++ b/src/hooks/report_creation.rs
@@ -5,7 +5,8 @@
 //! that creates the errors.
 //!
 //! **Note:** Hooks affect ALL errors globally. If you only need to attach data
-//! to a specific error, use `.attach()` directly instead of hooks.
+//! to a specific error, use [`.attach()`](crate::Report::attach) directly
+//! instead of hooks.
 //!
 //! # Hook Types (use in order of complexity)
 //!

--- a/src/into_report.rs
+++ b/src/into_report.rs
@@ -18,8 +18,8 @@ use crate::{markers, prelude::Report, report_collection::ReportCollection};
 /// # Automatic Implementations
 ///
 /// This trait is automatically implemented for:
-/// - All types implementing `std::error::Error` (converts to new `Report`)
-/// - Existing `Report` instances (performs identity or marker conversion)
+/// - All types implementing [`std::error::Error`] (converts to new [`Report`])
+/// - Existing [`Report`] instances (performs identity or marker conversion)
 ///
 /// # Thread Safety
 ///
@@ -27,9 +27,10 @@ use crate::{markers, prelude::Report, report_collection::ReportCollection};
 /// - [`markers::SendSync`]: Report can be sent across threads
 /// - [`markers::Local`]: Report is restricted to the current thread
 ///
-/// When converting from `SendSync` to `Local`, the conversion always succeeds.
-/// Converting from `Local` to `SendSync` is only available if the context type
-/// is `Send + Sync`.
+/// When converting from [`SendSync`](markers::SendSync) to
+/// [`Local`](markers::Local), the conversion always succeeds. Converting from
+/// [`Local`](markers::Local) to [`SendSync`](markers::SendSync) is only
+/// available if the context type is `Send + Sync`.
 ///
 /// # Typical Usage
 ///
@@ -123,17 +124,17 @@ where
 /// # Automatic Implementations
 ///
 /// This trait is automatically implemented for:
-/// - All types implementing `std::error::Error` (creates single-item
+/// - All types implementing [`std::error::Error`] (creates single-item
 ///   collection)
-/// - `Report` instances (creates single-item collection)
-/// - `ReportCollection` instances (identity or marker conversion)
+/// - [`Report`] instances (creates single-item collection)
+/// - [`ReportCollection`] instances (identity or marker conversion)
 ///
 /// # Typical Usage
 ///
 /// Most applications won't need to call this trait directly. Instead, consider:
 /// - Using iterator methods: `iter.map(|e| report!(e)).collect()`
 /// - Using `From` trait implementations for type conversions
-/// - Using `ReportCollection::new()` or builder methods
+/// - Using [`ReportCollection::new()`] or builder methods
 ///
 /// # Examples
 ///

--- a/src/markers.rs
+++ b/src/markers.rs
@@ -107,7 +107,7 @@ use crate::ReportMut;
 
 /// Marker type for reports with dynamic (type-erased) context.
 ///
-/// `Dynamic` is used as the context type parameter in
+/// [`Dynamic`] is used as the context type parameter in
 /// [`Report<Dynamic, O, T>`](crate::Report) to indicate that the actual error
 /// type at the root is not known at compile time. This is the default behavior
 /// and is similar to [`anyhow::Error`] - any error type
@@ -115,17 +115,17 @@ use crate::ReportMut;
 ///
 /// # Key Properties
 ///
-/// - **Zero-cost type erasure**: No actual instance of `Dynamic` is ever
+/// - **Zero-cost type erasure**: No actual instance of [`Dynamic`] is ever
 ///   stored. It's purely a marker type used at the type level.
 /// - **Automatic conversions**: The `?` operator automatically converts any
 ///   error type into `Report<Dynamic>`.
 /// - **Flexible propagation**: When you just need errors to propagate upward
-///   with context, `Dynamic` is the right choice.
+///   with context, [`Dynamic`] is the right choice.
 ///
 /// # When to Use Dynamic
 ///
 /// Use `Report<Dynamic>` (or just [`Report`](crate::Report), which defaults to
-/// `Dynamic`) when:
+/// [`Dynamic`]) when:
 /// - You're propagating errors upward and don't need to pattern match on
 ///   specific error types
 /// - You want the flexibility to return different error types from the same
@@ -230,9 +230,9 @@ use crate::ReportMut;
 ///
 /// [`examples/error_coercion.rs`]: https://github.com/rootcause-rs/rootcause/blob/main/examples/error_coercion.rs
 pub struct Dynamic {
-    /// This field ensures `Dynamic` is an unsized type.
+    /// This field ensures [`Dynamic`] is an unsized type.
     ///
-    /// Since the `Dynamic` type itself is never instantiated, the choice
+    /// Since the [`Dynamic`] type itself is never instantiated, the choice
     /// of an unsized type here is purely to enforce that property at the type
     /// level.
     _phantom_unsized: [()],
@@ -249,7 +249,7 @@ pub struct Dynamic {
 ///
 /// # Available Operations
 ///
-/// With `Mutable` ownership, you can:
+/// With [`Mutable`] ownership, you can:
 /// - Add attachments with [`attach`](crate::Report::attach)
 /// - Add parent context with [`context`](crate::Report::context)
 /// - Get mutable access with [`as_mut`](crate::Report::as_mut)
@@ -294,21 +294,21 @@ pub struct Mutable;
 /// For [`ReportRef<C, Cloneable>`](crate::ReportRef), the marker enables the
 /// [`clone_arc`](crate::ReportRef::clone_arc) method, which clones the
 /// underlying `Arc` to produce an owned [`Report<C, Cloneable,
-/// T>`](crate::Report). Note that `ReportRef` itself is always `Copy` and
-/// `Clone` regardless of the ownership marker - the `Cloneable`
-/// marker specifically enables converting the reference back to an owned
-/// report.
+/// T>`](crate::Report). Note that [`ReportRef`](crate::ReportRef) itself is
+/// always `Copy` and `Clone` regardless of the ownership marker - the
+/// [`Cloneable`] marker specifically enables converting the reference back to
+/// an owned report.
 ///
 /// # When to Use
 ///
-/// Use `Cloneable` reports when you need to:
+/// Use [`Cloneable`] reports when you need to:
 /// - Share an error report across multiple code paths
 /// - Store reports in collections that require `Clone`
 /// - Return the same error from multiple places without deep copying
 ///
 /// # Converting to Cloneable
 ///
-/// Convert a [`Mutable`] report to `Cloneable` using
+/// Convert a [`Mutable`] report to [`Cloneable`] using
 /// [`into_cloneable`](crate::Report::into_cloneable):
 ///
 /// ```
@@ -344,7 +344,7 @@ pub struct Mutable;
 /// process_error(report.into_cloneable());
 /// ```
 ///
-/// Using `clone_arc` on report references:
+/// Using [`clone_arc`](crate::ReportRef::clone_arc) on report references:
 ///
 /// ```
 /// use rootcause::{ReportRef, prelude::*};
@@ -367,22 +367,24 @@ pub struct Cloneable;
 /// indicates that the reference does not provide the
 /// [`clone_arc`](crate::ReportRef::clone_arc) method to obtain an owned report.
 ///
-/// Note that `ReportRef` itself is always `Copy` and `Clone` - you can always
-/// copy the reference itself. The `Uncloneable` marker only prevents cloning
-/// the underlying `Arc` to get an owned `Report`.
+/// Note that [`ReportRef`](crate::ReportRef) itself is always `Copy` and
+/// `Clone` - you can always copy the reference itself. The [`Uncloneable`]
+/// marker only prevents cloning the underlying `Arc` to get an owned
+/// [`Report`](crate::Report).
 ///
 /// # Common Uses
 ///
-/// `Uncloneable` references typically arise in two situations:
+/// [`Uncloneable`] references typically arise in two situations:
 ///
-/// 1. **Taking a reference to a `Mutable` report**: When you call
+/// 1. **Taking a reference to a [`Mutable`] report**: When you call
 ///    [`as_ref`](crate::Report::as_ref) on a `Report<C, Mutable>`, you get a
 ///    `ReportRef<C, Uncloneable>` because the underlying report has unique
 ///    ownership.
 ///
 /// 2. **Explicitly restricting cloneability**: You can convert a `ReportRef<C,
 ///    Cloneable>` to `ReportRef<C, Uncloneable>` when you want to pass a
-///    reference that explicitly cannot use `clone_arc`, ensuring the recipient
+///    reference that explicitly cannot use
+///    [`clone_arc`](crate::ReportRef::clone_arc), ensuring the recipient
 ///    can only inspect the report without obtaining ownership. This can be
 ///    useful in APIs that need to accept both cloneable and uncloneable
 ///    references.
@@ -390,7 +392,7 @@ pub struct Cloneable;
 ///
 /// # Examples
 ///
-/// Taking a reference to a `Mutable` report:
+/// Taking a reference to a [`Mutable`] report:
 ///
 /// ```
 /// use rootcause::{ReportRef, prelude::*};
@@ -407,7 +409,7 @@ pub struct Cloneable;
 /// // let owned = report_ref.clone_arc(); // ❌ Method not available
 /// ```
 ///
-/// Explicitly converting to `Uncloneable`:
+/// Explicitly converting to [`Uncloneable`]:
 ///
 /// ```
 /// use rootcause::{ReportRef, prelude::*};
@@ -435,7 +437,7 @@ pub struct Uncloneable;
 /// - Most standard library types
 /// - Types explicitly designed for concurrent use
 ///
-/// Use `SendSync` (the default) unless you have a specific need for
+/// Use [`SendSync`] (the default) unless you have a specific need for
 /// thread-local data.
 ///
 /// # Examples
@@ -468,7 +470,7 @@ pub struct SendSync;
 ///
 /// # When to Use
 ///
-/// Use `Local` when your error context or attachments contain:
+/// Use [`Local`] when your error context or attachments contain:
 /// - `Rc<T>` or `Weak<T>` (use `Arc<T>` for thread-safe alternative)
 /// - Raw pointers (`*const T`, `*mut T`)
 /// - Types that wrap thread-local storage
@@ -558,9 +560,9 @@ mod sealed_object_marker {
 /// The `RefMarker` associated type determines what kind of reference you get
 /// when calling [`as_ref`](crate::Report::as_ref):
 /// - For [`Mutable`], this is [`Uncloneable`] (the reference cannot use
-///   `clone_arc`)
+///   [`clone_arc`](crate::ReportRef::clone_arc))
 /// - For [`Cloneable`], this is [`Cloneable`] (the reference can use
-///   `clone_arc`)
+///   [`clone_arc`](crate::ReportRef::clone_arc))
 ///
 /// # Implementation
 ///

--- a/src/option_ext.rs
+++ b/src/option_ext.rs
@@ -75,7 +75,7 @@ pub struct NoneError {
 }
 
 impl NoneError {
-    /// Creates a new `NoneError` for the given type.
+    /// Creates a new [`NoneError`] for the given type.
     ///
     /// # Examples
     ///
@@ -315,9 +315,9 @@ pub trait OptionExt<V> {
     ///
     /// If `None`, creates a [`Report<NoneError>`] and transforms it using
     /// the [`ReportConversion`] implementation. Implement
-    /// [`ReportConversion`] once to define conversions, then use `context_to()`
-    /// at call sites. The target type `C` is typically inferred from the return
-    /// type.
+    /// [`ReportConversion`] once to define conversions, then use
+    /// [`context_to`](OptionExt::context_to) at call sites. The target type
+    /// `C` is typically inferred from the return type.
     ///
     /// See also: [`local_context_to`](OptionExt::local_context_to) (non-`Send +
     /// Sync` version).

--- a/src/report/mut_.rs
+++ b/src/report/mut_.rs
@@ -909,7 +909,8 @@ impl<'a, C: ?Sized, T> ReportMut<'a, C, T> {
     /// - Testing different formatters
     /// - Using different formatters in different parts of your application
     ///
-    /// Unlike the default `Display` and `Debug` implementations which use the
+    /// Unlike the default [`Display`](core::fmt::Display) and
+    /// [`Debug`](core::fmt::Debug) implementations which use the
     /// globally registered hook, this method uses the hook you provide
     /// directly.
     ///

--- a/src/report/owned.rs
+++ b/src/report/owned.rs
@@ -755,9 +755,9 @@ impl<C: ?Sized, O, T> Report<C, O, T> {
     /// [`ReportConversion`].
     ///
     /// Implement [`ReportConversion`] once to define conversion logic, then use
-    /// `context_to()` at call sites. Useful for consistent error type
-    /// coercion across your codebase, especially when integrating with
-    /// external libraries. You typically need to specify the target type
+    /// [`context_to`](Self::context_to) at call sites. Useful for consistent
+    /// error type coercion across your codebase, especially when integrating
+    /// with external libraries. You typically need to specify the target type
     /// (`::<Type>`).
     ///
     /// See also: [`context_transform`](Self::context_transform) for direct
@@ -1315,7 +1315,8 @@ impl<C: ?Sized, O, T> Report<C, O, T> {
     /// - Testing different formatters
     /// - Using different formatters in different parts of your application
     ///
-    /// Unlike the default `Display` and `Debug` implementations which use the
+    /// Unlike the default [`Display`](core::fmt::Display) and
+    /// [`Debug`](core::fmt::Debug) implementations which use the
     /// globally registered hook, this method uses the hook you provide
     /// directly.
     ///

--- a/src/report/ref_.rs
+++ b/src/report/ref_.rs
@@ -715,7 +715,8 @@ impl<'a, C: ?Sized, O, T> ReportRef<'a, C, O, T> {
     /// - Testing different formatters
     /// - Using different formatters in different parts of your application
     ///
-    /// Unlike the default `Display` and `Debug` implementations which use the
+    /// Unlike the default [`Display`](core::fmt::Display) and
+    /// [`Debug`](core::fmt::Debug) implementations which use the
     /// globally registered hook, this method uses the hook you provide
     /// directly.
     ///

--- a/src/report_collection/owned.rs
+++ b/src/report_collection/owned.rs
@@ -229,7 +229,7 @@ mod limit_field_access {
 pub use limit_field_access::ReportCollection;
 
 impl<C: ?Sized, T> ReportCollection<C, T> {
-    /// Creates a new, empty `ReportCollection`.
+    /// Creates a new, empty [`ReportCollection`].
     ///
     /// The collection will be initially empty and will have no capacity
     /// allocated. This method is equivalent to calling
@@ -259,7 +259,7 @@ impl<C: ?Sized, T> ReportCollection<C, T> {
         unsafe { Self::from_raw(reports) }
     }
 
-    /// Creates a new, empty `ReportCollection` with the specified capacity.
+    /// Creates a new, empty [`ReportCollection`] with the specified capacity.
     ///
     /// The collection will be able to hold at least `capacity` reports without
     /// reallocating. If you plan to add a known number of reports to the
@@ -801,7 +801,7 @@ impl<C: ?Sized, T> ReportCollection<C, T> {
 }
 
 impl<C: ?Sized> ReportCollection<C, SendSync> {
-    /// Creates a new, empty `ReportCollection` with [`SendSync`] thread safety.
+    /// Creates a new, empty [`ReportCollection`] with [`SendSync`] thread safety.
     ///
     /// This is equivalent to calling [`new()`](Self::new) but makes the thread
     /// safety marker explicit. The resulting collection can be safely sent
@@ -822,7 +822,7 @@ impl<C: ?Sized> ReportCollection<C, SendSync> {
 }
 
 impl<C: ?Sized> ReportCollection<C, Local> {
-    /// Creates a new, empty `ReportCollection` with [`Local`] thread safety.
+    /// Creates a new, empty [`ReportCollection`] with [`Local`] thread safety.
     ///
     /// This creates a collection that is not [`Send`] or [`Sync`], meaning it
     /// cannot be transferred between threads or shared across threads. This

--- a/src/report_collection/owned.rs
+++ b/src/report_collection/owned.rs
@@ -535,7 +535,8 @@ impl<C: ?Sized, T> ReportCollection<C, T> {
     /// - Testing different formatters
     /// - Using different formatters in different parts of your application
     ///
-    /// Unlike the default `Display` and `Debug` implementations which use the
+    /// Unlike the default [`Display`](core::fmt::Display) and
+    /// [`Debug`](core::fmt::Debug) implementations which use the
     /// globally registered hook, this method uses the hook you provide
     /// directly.
     ///

--- a/src/result_ext.rs
+++ b/src/result_ext.rs
@@ -232,9 +232,9 @@ pub trait ResultExt<V, E> {
     ///
     /// If `Err`, converts the error into a [`Report`] and transforms it using
     /// the [`ReportConversion`] implementation. Implement
-    /// [`ReportConversion`] once to define conversions, then use `context_to()`
-    /// at call sites. The target type `C` is typically inferred from the return
-    /// type.
+    /// [`ReportConversion`] once to define conversions, then use
+    /// [`context_to`](ResultExt::context_to) at call sites. The target type
+    /// `C` is typically inferred from the return type.
     ///
     /// See also: [`local_context_to`](ResultExt::local_context_to) (non-`Send +
     /// Sync` version), [`examples/thiserror_interop.rs`] (integration


### PR DESCRIPTION
Mechanical intradoc-link conversion across public docs per the style
guide. No behavior or API changes.

Redoes the goal of #152 against current main.