### PR TITLE
Add some extra soundness tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,6 +91,13 @@ jobs:
       matrix:
         # The windows miri support doesn't seem to be working well currently
         os: [ubuntu-latest, macos-latest]
+        # Run under both aliasing models. The two are not nested: some UB is
+        # only caught by one model, so testing both maximizes coverage.
+        borrow-model:
+          - name: Stacked Borrows
+            flags: ""
+          - name: Tree Borrows
+            flags: "-Zmiri-tree-borrows"
 
     runs-on: ${{ matrix.os }}
 
@@ -105,13 +112,13 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Run tests with miri
+      - name: Run tests with miri (${{ matrix.borrow-model.name }})
         run: |
-          export MIRIFLAGS="-Zmiri-strict-provenance"
+          export MIRIFLAGS="-Zmiri-strict-provenance ${{ matrix.borrow-model.flags }}"
           cargo miri test -p rootcause -p rootcause-internals -p rootcause-tracing -p rootcause-preformat --all-targets
           cargo miri test -p rootcause -p rootcause-internals -p rootcause-tracing -p rootcause-preformat --all-features --all-targets
 
-          export MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-isolation-error=warn"
+          export MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-isolation-error=warn ${{ matrix.borrow-model.flags }}"
           cargo miri test -p rootcause -p rootcause-internals -p rootcause-tracing -p rootcause-preformat --doc
           cargo miri test -p rootcause -p rootcause-internals -p rootcause-tracing -p rootcause-preformat --doc --all-features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "atomic-waker"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustc-hash = { version = "2.1.2", default-features = false }
 triomphe = { version = "0.1.15", default-features = false }
 
 # Optional dependencies
-anyhow = { version = "1.0.102", default-features = false, optional = true }
+anyhow = { version = "1.0.103", default-features = false, optional = true }
 error-stack05 = { package = "error-stack", version = "0.5.0", default-features = false, optional = true }
 error-stack06 = { package = "error-stack", version = "0.6.0", default-features = false, optional = true }
 error-stack07 = { package = "error-stack", version = "0.7.1", default-features = false, optional = true }

--- a/tests/downcast_mut_soundness.rs
+++ b/tests/downcast_mut_soundness.rs
@@ -1,0 +1,106 @@
+//! Soundness test for mutable context downcasting.
+//!
+//! Type-erased mutable downcasting must produce its `&mut T` from a pointer that
+//! carries provenance over the whole allocation, never from a shared reference.
+//! Deriving a `&mut` from a `&` (even a transient one anywhere in the chain) is
+//! undefined behavior, because the optimizer may assume a shared reference never
+//! changes, making a write through the resulting `&mut` invalid.
+//!
+//! rootcause's mutable path (`RawReportMut`) carries a `NonNull` that retains
+//! full provenance over the `Arc` allocation (from `triomphe::Arc::into_raw`)
+//! and builds the `&mut` from that pointer directly. Each test below takes a
+//! `&mut` through a public mutable-downcast entry point and writes through it,
+//! so Miri can verify the write violates no aliasing rule. Run under both
+//! aliasing models:
+//!
+//! ```text
+//! cargo miri test --test downcast_mut_soundness
+//! MIRIFLAGS=-Zmiri-tree-borrows cargo miri test --test downcast_mut_soundness
+//! ```
+//!
+//! The same class of bug was found in several other error libraries; see
+//! zkat/miette#469, dtolnay/anyhow#451, and eyre-rs/eyre#285 for background.
+
+use core::fmt;
+
+use rootcause::{Report, markers::Dynamic, prelude::*};
+
+/// A minimal context whose `message` can be mutated in place, giving the
+/// mutable downcasts something to write to.
+#[derive(Debug)]
+struct Ctx {
+    message: String,
+}
+
+impl Ctx {
+    fn new(message: &str) -> Self {
+        Ctx {
+            message: message.to_owned(),
+        }
+    }
+}
+
+impl fmt::Display for Ctx {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+/// `Report::current_context_mut` -> `&mut C`.
+#[test]
+fn current_context_mut_allows_write() {
+    let mut report: Report<Ctx> = report!(Ctx::new("start"));
+
+    report.current_context_mut().message.push_str("-edited");
+
+    assert_eq!(report.current_context().message, "start-edited");
+}
+
+/// `Report::current_context_as_any_mut` -> `&mut dyn Any` -> `&mut C`.
+#[test]
+fn current_context_as_any_mut_allows_write() {
+    let mut report: Report<Ctx> = report!(Ctx::new("start"));
+
+    let any = report.current_context_as_any_mut();
+    any.downcast_mut::<Ctx>()
+        .expect("context is Ctx")
+        .message
+        .push_str("-edited");
+
+    assert_eq!(report.current_context().message, "start-edited");
+}
+
+/// `ReportMut::downcast_current_context_mut` on a type-erased report -> `&mut C`.
+#[test]
+fn downcast_current_context_mut_allows_write() {
+    let mut report: Report<Dynamic> = report!(Ctx::new("start")).into_dynamic();
+
+    report
+        .as_mut()
+        .downcast_current_context_mut::<Ctx>()
+        .expect("current context is Ctx")
+        .message
+        .push_str("-edited");
+
+    assert_eq!(
+        report
+            .as_ref()
+            .downcast_current_context::<Ctx>()
+            .unwrap()
+            .message,
+        "start-edited"
+    );
+}
+
+/// The same mutable downcast, but on a report that owns a child so the backing
+/// allocation is non-trivial (real vtable, populated children vector).
+#[test]
+fn downcast_mut_on_report_with_child() {
+    let child: Report<Ctx> = report!(Ctx::new("child"));
+    let mut parent: Report<Ctx> = child.context(Ctx::new("parent"));
+    assert_eq!(parent.children().len(), 1);
+
+    parent.current_context_mut().message.push_str("-edited");
+
+    assert_eq!(parent.current_context().message, "parent-edited");
+}


### PR DESCRIPTION
Recently some `pointer->reference->pointer` soundness issues have been identified in other error handling libraries.

See zkat/miette#469, dtolnay/anyhow#451, and eyre-rs/eyre#285 for background.

This kind of issue has not been identified in rootcause. We already test using miri and our unsafe blocks have been heavily scrutinized.

Nevertheless, this is probably a good time to tighten our security stance a bit by improving how we run our CI and by adding some dedicated tests for this kind of issue.