### PR TITLE
Run cargo-deny on the entire workspace

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: Run cargo-deny
         uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          arguments: --all-features --workspace
 
   nightly-doc-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CI previously ran cargo-deny only against the root `rootcause` package, so the other workspace members (`rootcause-backtrace`, `rootcause-tracing`, `rootcause-preformat`) and their dependencies were never checked. A side effect was a `license-not-encountered` warning for `Unicode-3.0`, which is required by `unicode-ident` in `rootcause-backtrace`.

Pass `--workspace` to the cargo-deny action (keeping its default `--all-features`) so the whole workspace is checked. `cargo deny --all-features --workspace check` now passes cleanly on top of #191.