### PR TITLE
Document the depth-first pre-order of `ReportIter` as a guarantee

### DIFF
--- a/src/report/iter.rs
+++ b/src/report/iter.rs
@@ -4,12 +4,37 @@ use core::{iter::FusedIterator, marker::PhantomData};
 use crate::{ReportRef, markers::Dynamic};
 
 /// An iterator over a report and all its descendant reports in depth-first
-/// order.
+/// pre-order.
 ///
 /// This iterator yields [`ReportRef`] items, which are references to the reports
-/// in the hierarchy. The iterator traverses the report tree in a depth-first
-/// manner, starting from the root report and visiting each child report before
-/// moving to the next sibling.
+/// in the hierarchy. The traversal order is guaranteed to be depth-first
+/// pre-order: each report is yielded before its descendants, and each child's
+/// entire subtree is yielded before the next sibling. Children are visited in
+/// the order they appear in [`ReportRef::children`].
+///
+/// # Examples
+///
+/// ```
+/// # use rootcause::prelude::*;
+/// # let mut a: Report = report!("a");
+/// # a.children_mut().push(report!("a1").into_cloneable());
+/// # a.children_mut().push(report!("a2").into_cloneable());
+/// # let mut b: Report = report!("b");
+/// # b.children_mut().push(report!("b1").into_cloneable());
+/// # let mut root: Report = report!("root");
+/// # root.children_mut().push(a.into_cloneable());
+/// # root.children_mut().push(b.into_cloneable());
+/// // The report tree:      root
+/// //                      /    \
+/// //                     a      b
+/// //                    / \      \
+/// //                   a1  a2     b1
+/// let order: Vec<String> = root
+///     .iter_reports()
+///     .map(|report| report.format_current_context().to_string())
+///     .collect();
+/// assert_eq!(order, ["root", "a", "a1", "a2", "b", "b1"]);
+/// ```
 #[must_use]
 pub struct ReportIter<'a, Ownership: 'static, ThreadSafety: 'static> {
     stack: Vec<ReportRef<'a, Dynamic, Ownership, ThreadSafety>>,
@@ -59,11 +84,12 @@ impl<'a, O, T> FusedIterator for ReportIter<'a, O, T> {}
 
 impl<'a, O, T> Unpin for ReportIter<'a, O, T> {}
 
-/// An iterator over all contexts that can successfully be downcasted to `D`, belonging
-/// a report and all its decendants in a depth-first order.
+/// An iterator over all contexts that can successfully be downcasted to `D`,
+/// belonging to a report and all its descendants.
 ///
 /// This iterator yields `&D` items, which are references to the reports' contexts
-/// in the hierarchy.
+/// in the hierarchy. Matches are yielded in the same guaranteed depth-first
+/// pre-order as [`ReportIter`].
 pub struct DowncastIterator<'a, D, Ownership: 'static, ThreadSafety: 'static> {
     pub(crate) iter: ReportIter<'a, Ownership, ThreadSafety>,
     pub(crate) _phantom: PhantomData<D>,

--- a/src/report/mut_.rs
+++ b/src/report/mut_.rs
@@ -610,9 +610,8 @@ impl<'a, C: ?Sized, T> ReportMut<'a, C, T> {
     /// Returns an iterator over the complete report hierarchy including this
     /// report.
     ///
-    /// The iterator visits reports in a depth-first order: it first visits the
-    /// current report, then recursively visits each child report and all of
-    /// their descendants before moving to the next sibling. Unlike
+    /// The iterator yields this report first, followed by its descendants in
+    /// the depth-first pre-order guaranteed by [`ReportIter`]. Unlike
     /// [`ReportMut::iter_sub_reports`], this method includes the report on
     /// which it was called as the first item in the iteration.
     ///
@@ -661,9 +660,8 @@ impl<'a, C: ?Sized, T> ReportMut<'a, C, T> {
     /// Returns an iterator over child reports in the report hierarchy
     /// (excluding this report).
     ///
-    /// The iterator visits reports in a depth-first order: it first visits the
-    /// current report's children, then recursively visits each child report
-    /// and all of their descendants before moving to the next sibling.
+    /// The iterator yields the descendants of this report in the depth-first
+    /// pre-order guaranteed by [`ReportIter`].
     /// Unlike [`ReportMut::iter_reports`], this method does NOT include the
     /// report on which it was called - only its descendants.
     ///

--- a/src/report/owned.rs
+++ b/src/report/owned.rs
@@ -1056,9 +1056,8 @@ impl<C: ?Sized, O, T> Report<C, O, T> {
     /// Returns an iterator over the complete report hierarchy including this
     /// report.
     ///
-    /// The iterator visits reports in a depth-first order: it first visits the
-    /// current report, then recursively visits each child report and all of
-    /// their descendants before moving to the next sibling. Unlike
+    /// The iterator yields this report first, followed by its descendants in
+    /// the depth-first pre-order guaranteed by [`ReportIter`]. Unlike
     /// [`Report::iter_sub_reports`], this method includes the report on
     /// which it was called as the first item in the iteration.
     ///
@@ -1115,9 +1114,8 @@ impl<C: ?Sized, O, T> Report<C, O, T> {
     /// Returns an iterator over child reports in the report hierarchy
     /// (excluding this report).
     ///
-    /// The iterator visits reports in a depth-first order: it first visits the
-    /// current report's children, then recursively visits each child report
-    /// and all of their descendants before moving to the next sibling.
+    /// The iterator yields the descendants of this report in the depth-first
+    /// pre-order guaranteed by [`ReportIter`].
     /// Unlike [`Report::iter_reports`], this method does NOT include the
     /// report on which it was called - only its descendants.
     ///
@@ -1571,8 +1569,8 @@ impl<O, T> Report<Dynamic, O, T> {
     /// be downcast to the specified type `D`.
     ///
     /// Iterates over the complete report hierarchy (including this report)
-    /// using [`iter_reports`](Self::iter_reports) and yields references to
-    /// contexts that successfully downcast to `D`.
+    /// and yields references to contexts that successfully downcast to `D`,
+    /// in the depth-first pre-order guaranteed by [`ReportIter`].
     ///
     /// This is a convenience method combining
     /// [`iter_reports`](Self::iter_reports) with

--- a/src/report/ref_.rs
+++ b/src/report/ref_.rs
@@ -462,9 +462,8 @@ impl<'a, C: ?Sized, O, T> ReportRef<'a, C, O, T> {
     /// Returns an iterator over the complete report hierarchy including this
     /// report.
     ///
-    /// The iterator visits reports in a depth-first order: it first visits the
-    /// current report, then recursively visits each child report and all of
-    /// their descendants before moving to the next sibling. Unlike
+    /// The iterator yields this report first, followed by its descendants in
+    /// the depth-first pre-order guaranteed by [`ReportIter`]. Unlike
     /// [`ReportRef::iter_sub_reports`], this method includes the report on
     /// which it was called as the first item in the iteration.
     ///
@@ -516,9 +515,8 @@ impl<'a, C: ?Sized, O, T> ReportRef<'a, C, O, T> {
     /// Returns an iterator over child reports in the report hierarchy
     /// (excluding this report).
     ///
-    /// The iterator visits reports in a depth-first order: it first visits the
-    /// current report's children, then recursively visits each child report
-    /// and all of their descendants before moving to the next sibling.
+    /// The iterator yields the descendants of this report in the depth-first
+    /// pre-order guaranteed by [`ReportIter`].
     /// Unlike [`ReportRef::iter_reports`], this method does NOT include the
     /// report on which it was called - only its descendants.
     ///


### PR DESCRIPTION
The iteration order of `ReportIter` was described informally at each entry point but never stated as a contract. This PR makes depth-first pre-order an explicit guarantee, documented once on `ReportIter` with an order-asserting example on a branching tree, and thins the `iter_reports`/`iter_sub_reports`/`iter_downcast_context` docs to reference it (per the revised style guide's push-shared-explanation-up rule).

Users writing first-match searches (e.g. `iter_downcast_context::<D>().next()`) can now rely on the order.